### PR TITLE
Extend interface context

### DIFF
--- a/context_test.go
+++ b/context_test.go
@@ -175,7 +175,7 @@ func TestWrapF(t *testing.T) {
 	assert.Equal(t, "fox", w.Body.String())
 }
 
-func TestWrapFH(t *testing.T) {
+func TestWrapH(t *testing.T) {
 	wrapped := WrapH(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		_, _ = w.Write([]byte("fox"))
 	}))

--- a/error.go
+++ b/error.go
@@ -20,6 +20,9 @@ var (
 	ErrInvalidRedirectCode     = errors.New("invalid redirect code")
 )
 
+// RouteConflictError is a custom error type used to represent conflicts when
+// registering or updating routes in the router. It holds information about the
+// conflicting method, path, and the matched routes that caused the conflict.
 type RouteConflictError struct {
 	err      error
 	Method   string
@@ -40,6 +43,7 @@ func newConflictErr(method, path, catchAllKey string, matched []string) *RouteCo
 	}
 }
 
+// Error returns a formatted error message for the RouteConflictError.
 func (e *RouteConflictError) Error() string {
 	if !e.isUpdate {
 		return e.insertError()
@@ -56,13 +60,14 @@ func (e *RouteConflictError) updateError() string {
 
 }
 
+// Unwrap returns the sentinel value ErrRouteConflict.
 func (e *RouteConflictError) Unwrap() error {
 	return e.err
 }
 
-// HTTPError represents an HTTP error with a status code (HTTPErrorCode)
-// and an optional error message. If no error message is provided,
-// the default error message for the status code will be used.
+// HTTPError represents an HTTP error with a status code and an optional
+// error message. If no error message is provided, the default error message
+// for the status code will be used.
 type HTTPError struct {
 	Err  error
 	Code int

--- a/fox.go
+++ b/fox.go
@@ -276,8 +276,7 @@ func (fox *Router) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	n, tsr = tree.lookup(nds[index], r.URL.Path, c.params, c.skipNds, false)
 	if n != nil {
 		c.path = n.path
-		err := n.handler(c)
-		if err != nil {
+		if err := n.handler(c); err != nil {
 			fox.errRoute(c, err)
 		}
 		// Put back the context, if not extended more than max params or max depth, allowing
@@ -341,8 +340,7 @@ NoMethodFallback:
 		allowed := sb.String()
 		if allowed != "" {
 			w.Header().Set("Allow", allowed)
-			err := fox.noMethod(c)
-			if err != nil {
+			if err := fox.noMethod(c); err != nil {
 				fox.errRoute(c, err)
 			}
 			c.Close()
@@ -350,8 +348,7 @@ NoMethodFallback:
 		}
 	}
 
-	err := fox.noRoute(c)
-	if err != nil {
+	if err := fox.noRoute(c); err != nil {
 		fox.errRoute(c, err)
 	}
 	c.Close()

--- a/fox_test.go
+++ b/fox_test.go
@@ -14,6 +14,7 @@ import (
 	"math/rand"
 	"net/http"
 	"net/http/httptest"
+	"reflect"
 	"regexp"
 	"strings"
 	"sync"
@@ -1644,6 +1645,16 @@ func TestRouterWithAllowedMethod(t *testing.T) {
 			assert.Equal(t, tc.want, w.Header().Get("Allow"))
 		})
 	}
+}
+
+func TestDefaultOptions(t *testing.T) {
+	m := MiddlewareFunc(func(next HandlerFunc) HandlerFunc {
+		return func(c Context) error {
+			return next(c)
+		}
+	})
+	r := New(WithMiddleware(m), DefaultOptions())
+	assert.Equal(t, reflect.ValueOf(m).Pointer(), reflect.ValueOf(r.mws[1]).Pointer())
 }
 
 func TestRecoveryMiddleware(t *testing.T) {

--- a/fox_test.go
+++ b/fox_test.go
@@ -2106,7 +2106,13 @@ func ExampleWithMiddleware() {
 		return func(c Context) error {
 			start := time.Now()
 			err := next(c)
-			log.Printf("url=%s; route=%s; time=%d; status=%d", c.Request().URL, c.Path(), time.Since(start), c.Writer().Status())
+			log.Printf(
+				"url=%s; route=%s; time=%d; status=%d",
+				c.Request().URL,
+				c.Path(),
+				time.Since(start),
+				c.Writer().Status(),
+			)
 			return err
 		}
 	}
@@ -2143,7 +2149,7 @@ func ExampleRouter_Tree() {
 	})
 
 	// Bad, instead make a local copy of the tree!
-	upsert = func(method, path string, handler HandlerFunc) error {
+	_ = func(method, path string, handler HandlerFunc) error {
 		r.Tree().Lock()
 		defer r.Tree().Unlock()
 		if Has(r.Tree(), method, path) {

--- a/http_consts.go
+++ b/http_consts.go
@@ -63,6 +63,7 @@ const (
 	HeaderOrigin              = "Origin"
 	HeaderCacheControl        = "Cache-Control"
 	HeaderConnection          = "Connection"
+	HeaderETag                = "ETag"
 
 	// Access control
 	HeaderAccessControlRequestMethod    = "Access-Control-Request-Method"

--- a/options.go
+++ b/options.go
@@ -86,6 +86,6 @@ func WithRedirectTrailingSlash(enable bool) Option {
 // Note that DefaultOptions push the Recovery middleware to the first position of the middleware chains.
 func DefaultOptions() Option {
 	return optionFunc(func(r *Router) {
-		r.mws = append([]MiddlewareFunc{Recovery(defaultHandleRecovery)}, r.mws...)
+		r.mws = append([]MiddlewareFunc{Recovery(DefaultHandleRecovery)}, r.mws...)
 	})
 }

--- a/options.go
+++ b/options.go
@@ -83,8 +83,9 @@ func WithRedirectTrailingSlash(enable bool) Option {
 }
 
 // DefaultOptions configure the router to use the Recovery middleware.
+// Note that DefaultOptions push the Recovery middleware to the first position of the middleware chains.
 func DefaultOptions() Option {
 	return optionFunc(func(r *Router) {
-		r.mws = append(r.mws, Recovery(defaultHandleRecovery))
+		r.mws = append([]MiddlewareFunc{Recovery(defaultHandleRecovery)}, r.mws...)
 	})
 }

--- a/recovery.go
+++ b/recovery.go
@@ -42,7 +42,7 @@ func recovery(c Context, handle RecoveryFunc) {
 	}
 }
 
-func defaultHandleRecovery(c Context, err any) {
+func DefaultHandleRecovery(c Context, err any) {
 	stdErr.Printf("[PANIC] %q panic recovered\n%s", err, debug.Stack())
 	if !c.Writer().Written() && !connIsBroken(err) {
 		http.Error(c.Writer(), http.StatusText(http.StatusInternalServerError), http.StatusInternalServerError)

--- a/response_writer.go
+++ b/response_writer.go
@@ -32,6 +32,10 @@ type ResponseWriter interface {
 	Size() int
 	// Unwrap returns the underlying http.ResponseWriter.
 	Unwrap() http.ResponseWriter
+	// WriteString writes the provided string to the underlying connection
+	// as part of an HTTP reply. The method returns the number of bytes written
+	// and an error, if any.
+	WriteString(s string) (int, error)
 }
 
 const notWritten = -1

--- a/test_helpers.go
+++ b/test_helpers.go
@@ -11,6 +11,7 @@ func NewTestContext(w http.ResponseWriter, r *http.Request) (*Router, Context) {
 	return fox, c
 }
 
+// NewTestContextOnly returns a new Context associated with the provided Router, designed only for testing purpose.
 func NewTestContextOnly(fox *Router, w http.ResponseWriter, r *http.Request) Context {
 	return newTextContextOnly(fox, w, r)
 }


### PR DESCRIPTION
### New Features
- Added `Header` and `GetHeader` methods to the `Context` interface, providing a more convenient way to interact with request and response headers.
- Introduced the `Ctx` method in the `Context` interface, allowing easy access to the request's context.

### Improvements
Enhanced the documentation throughout the codebase to provide better clarity and guidance.