### PR TITLE
Update HandlerFunc type

### DIFF
--- a/README.md
+++ b/README.md
@@ -393,7 +393,6 @@ to create and apply automatically a simple logging middleware to all route.
 package main
 
 import (
-	"fmt"
 	"github.com/tigerwill90/fox"
 	"log"
 	"net/http"
@@ -404,13 +403,12 @@ func Logger(next fox.HandlerFunc) fox.HandlerFunc {
 	return func(c fox.Context) {
 		start := time.Now()
 		next(c)
-		msg := fmt.Sprintf("route: %s, latency: %s, status: %d, size: %d",
+		log.Printf("route: %s, latency: %s, status: %d, size: %d",
 			c.Path(),
 			time.Since(start),
 			c.Writer().Status(),
 			c.Writer().Size(),
 		)
-		log.Println(msg)
 	}
 }
 

--- a/README.md
+++ b/README.md
@@ -58,15 +58,15 @@ type Greeting struct {
 	Say string
 }
 
-func (h *Greeting) Greet(c fox.Context) error {
-	return c.String(http.StatusOK, "%s %s\n", h.Say, c.Param("name"))
+func (h *Greeting) Greet(c fox.Context) {
+	_ = c.String(http.StatusOK, "%s %s\n", h.Say, c.Param("name"))
 }
 
 func main() {
 	r := fox.New(fox.DefaultOptions())
 
-	err := r.Handle(http.MethodGet, "/", func(c fox.Context) error {
-		return c.String(http.StatusOK, "Welcome\n")
+	err := r.Handle(http.MethodGet, "/", func(c fox.Context) {
+		_ = c.String(http.StatusOK, "Welcome\n")
 	})
 	if err != nil {
 		panic(err)
@@ -96,29 +96,6 @@ if errors.Is(err, fox.ErrRouteConflict) {
     }
 }
 ```
-
-In addition, Fox also provides a centralized way to handle errors that may occur during the execution of a HandlerFunc.
-
-````go
-var MyCustomError = errors.New("my custom error")
-
-r := fox.New(
-    fox.WithRouteError(func(c fox.Context, err error) {
-        if !c.Writer().Written() {
-            if errors.Is(err, MyCustomError) {
-                http.Error(c.Writer(), err.Error(), http.StatusInternalServerError)
-                return
-            }
-            http.Error(c.Writer(), http.StatusText(http.StatusInternalServerError), http.StatusInternalServerError)
-            return
-        }
-    }),
-)
-
-r.MustHandle(http.MethodGet, "/hello/{name}", func(c fox.Context) error {
-    return MyCustomError
-})
-````
 
 #### Named parameters
 A route can be defined using placeholder (e.g `{name}`). The matching segment are recorder into the `fox.Params` slice accessible 
@@ -175,14 +152,14 @@ POST /users/{name}/emails
 The `fox.Context` instance is freed once the request handler function returns to optimize resource allocation.
 If you need to retain `fox.Context` or `fox.Params` beyond the scope of the handler, use the `Clone` methods.
 ````go
-func Hello(c fox.Context) error {
+func Hello(c fox.Context) {
     cc := c.Clone()
     // cp := c.Params().Clone()
     go func() {
         time.Sleep(2 * time.Second)
         log.Println(cc.Param("name")) // Safe
     }()
-    return c.String(http.StatusOK, "Hello %s\n", c.Param("name"))
+    _ = c.String(http.StatusOK, "Hello %s\n", c.Param("name"))
 }
 ````
 
@@ -219,7 +196,6 @@ package main
 
 import (
 	"encoding/json"
-	"errors"
 	"fmt"
 	"github.com/tigerwill90/fox"
 	"log"
@@ -227,10 +203,11 @@ import (
 	"strings"
 )
 
-func Action(c fox.Context) error {
+func Action(c fox.Context) {
 	var data map[string]string
 	if err := json.NewDecoder(c.Request().Body).Decode(&data); err != nil {
-		return fox.NewHTTPError(http.StatusBadRequest, err)
+		http.Error(c.Writer(), err.Error(), http.StatusBadRequest)
+		return
 	}
 
 	method := strings.ToUpper(data["method"])
@@ -238,30 +215,33 @@ func Action(c fox.Context) error {
 	text := data["text"]
 
 	if path == "" || method == "" {
-		return fox.NewHTTPError(http.StatusBadRequest, errors.New("missing method or path"))
+		http.Error(c.Writer(), "missing method or path", http.StatusBadRequest)
+		return
 	}
 
 	var err error
 	action := c.Param("action")
 	switch action {
 	case "add":
-		err = c.Fox().Handle(method, path, func(c fox.Context) error {
-			return c.String(http.StatusOK, text)
+		err = c.Fox().Handle(method, path, func(c fox.Context) {
+			_ = c.String(http.StatusOK, text)
 		})
 	case "update":
-		err = c.Fox().Update(method, path, func(c fox.Context) error {
-			return c.String(http.StatusOK, text)
+		err = c.Fox().Update(method, path, func(c fox.Context) {
+			_ = c.String(http.StatusOK, text)
 		})
 	case "delete":
 		err = c.Fox().Remove(method, path)
 	default:
-		return fox.NewHTTPError(http.StatusBadRequest, fmt.Errorf("action %q is not allowed", action))
+		http.Error(c.Writer(), fmt.Sprintf("action %q is not allowed", action), http.StatusBadRequest)
+		return
 	}
 	if err != nil {
-		return fox.NewHTTPError(http.StatusConflict, err)
+		http.Error(c.Writer(), err.Error(), http.StatusConflict)
+		return
 	}
 
-	return c.String(http.StatusOK, "%s route [%s] %s: success\n", action, method, path)
+	_ = c.String(http.StatusOK, "%s route [%s] %s: success\n", action, method, path)
 }
 
 func main() {
@@ -292,9 +272,9 @@ type HtmlRenderer struct {
 	Template template.HTML
 }
 
-func (h *HtmlRenderer) Render(c fox.Context) error {
+func (h *HtmlRenderer) Render(c fox.Context) {
 	log.Printf("matched handler path: %s", c.Path())
-	return c.Stream(
+	_ = c.Stream(
 		http.StatusInternalServerError,
 		fox.MIMETextHTMLCharsetUTF8,
 		strings.NewReader(string(h.Template)),
@@ -304,20 +284,13 @@ func (h *HtmlRenderer) Render(c fox.Context) error {
 func main() {
 	r := fox.New()
 
-	routes := db.GetRoutes()
-
-	for _, rte := range routes {
-		h := HtmlRenderer{Template: rte.Template}
-		r.MustHandle(rte.Method, rte.Path, h.Render)
-	}
-
 	go Reload(r)
 
 	log.Fatalln(http.ListenAndServe(":8080", r))
 }
 
 func Reload(r *fox.Router) {
-	for range time.Tick(10 * time.Second) {
+	for ; true; <-time.Tick(10 * time.Second) {
 		routes := db.GetRoutes()
 		tree := r.NewTree()
 		for _, rte := range routes {
@@ -374,10 +347,9 @@ r.Tree().Lock()
 defer r.Tree().Unlock()
 
 // Dramatically bad, may cause deadlock
-func handle(c fox.Context) error {
+func handle(c fox.Context) {
     c.Fox().Tree().Lock()
     defer c.Fox().Tree().Unlock()
-    return nil
 }
 ```` 
 
@@ -385,10 +357,9 @@ Note that `fox.Context` carries a local copy of the `Tree` that is being used to
 the risk of deadlock when using the `Tree` within the context.
 ````go
 // Ok
-func handle(c fox.Context) error {
+func handle(c fox.Context) {
     c.Tree().Lock()
     defer c.Tree().Unlock()
-    return nil
 }
 ````
 
@@ -409,8 +380,8 @@ r.MustHandle(http.MethodGet, "/articles", fox.WrapH(httpRateLimiter.RateLimit(ar
 Wrapping an `http.Handler` compatible middleware
 ````go
 r := fox.New(fox.DefaultOptions(), fox.WithMiddleware(fox.WrapM(httpRateLimiter.RateLimit)))
-r.MustHandle(http.MethodGet, "/articles/{id}", func(c fox.Context) error {
-    return c.String(http.StatusOK, "Article id: %s\n", c.Param("id"))
+r.MustHandle(http.MethodGet, "/articles/{id}", func(c fox.Context) {
+    _ = c.String(http.StatusOK, "Article id: %s\n", c.Param("id"))
 })
 ````
 
@@ -429,34 +400,31 @@ import (
 	"time"
 )
 
-var logger = fox.MiddlewareFunc(func(next fox.HandlerFunc) fox.HandlerFunc {
-	return func(c fox.Context) error {
+func Logger(next fox.HandlerFunc) fox.HandlerFunc {
+	return func(c fox.Context) {
 		start := time.Now()
-		err := next(c)
+		next(c)
 		msg := fmt.Sprintf("route: %s, latency: %s, status: %d, size: %d",
 			c.Path(),
 			time.Since(start),
 			c.Writer().Status(),
 			c.Writer().Size(),
 		)
-		if err != nil {
-			msg += fmt.Sprintf(", error: %s", err)
-		}
 		log.Println(msg)
-		return err
 	}
-})
+}
 
 func main() {
-	r := fox.New(fox.WithMiddleware(logger))
+	r := fox.New(fox.WithMiddleware(Logger))
 
-	r.MustHandle(http.MethodGet, "/", func(c fox.Context) error {
+	r.MustHandle(http.MethodGet, "/", func(c fox.Context) {
 		resp, err := http.Get("https://api.coindesk.com/v1/bpi/currentprice.json")
 		if err != nil {
-			return fox.NewHTTPError(http.StatusInternalServerError)
+			http.Error(c.Writer(), http.StatusText(http.StatusInternalServerError), http.StatusInternalServerError)
+			return
 		}
 		defer resp.Body.Close()
-		return c.Stream(http.StatusOK, fox.MIMEApplicationJSON, resp.Body)
+		_ = c.Stream(http.StatusOK, fox.MIMEApplicationJSON, resp.Body)
 	})
 
 	log.Fatalln(http.ListenAndServe(":8080", r))

--- a/context.go
+++ b/context.go
@@ -257,17 +257,15 @@ func (c *context) getQueries() url.Values {
 
 // WrapF is an adapter for wrapping http.HandlerFunc and returns a HandlerFunc function.
 func WrapF(f http.HandlerFunc) HandlerFunc {
-	return func(c Context) error {
+	return func(c Context) {
 		f.ServeHTTP(c.Writer(), c.Request())
-		return nil
 	}
 }
 
 // WrapH is an adapter for wrapping http.Handler and returns a HandlerFunc function.
 func WrapH(h http.Handler) HandlerFunc {
-	return func(c Context) error {
+	return func(c Context) {
 		h.ServeHTTP(c.Writer(), c.Request())
-		return nil
 	}
 }
 
@@ -275,13 +273,11 @@ func WrapH(h http.Handler) HandlerFunc {
 // MiddlewareFunc function.
 func WrapM(m func(handler http.Handler) http.Handler) MiddlewareFunc {
 	return func(next HandlerFunc) HandlerFunc {
-		return func(c Context) error {
-			var err error
+		return func(c Context) {
 			adapter := m(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-				err = next(c)
+				next(c)
 			}))
 			adapter.ServeHTTP(c.Writer(), c.Request())
-			return err
 		}
 	}
 }

--- a/context_test.go
+++ b/context_test.go
@@ -171,7 +171,7 @@ func TestWrapF(t *testing.T) {
 	w := httptest.NewRecorder()
 	r := httptest.NewRequest(http.MethodGet, "https://example.com/foo", nil)
 	_, c := NewTestContext(w, r)
-	require.NoError(t, wrapped(c))
+	wrapped(c)
 	assert.Equal(t, "fox", w.Body.String())
 }
 
@@ -183,7 +183,7 @@ func TestWrapH(t *testing.T) {
 	w := httptest.NewRecorder()
 	r := httptest.NewRequest(http.MethodGet, "https://example.com/foo", nil)
 	_, c := NewTestContext(w, r)
-	require.NoError(t, wrapped(c))
+	wrapped(c)
 	assert.Equal(t, "fox", w.Body.String())
 }
 
@@ -200,9 +200,8 @@ func TestWrapM(t *testing.T) {
 	r := httptest.NewRequest(http.MethodGet, "https://example.com/foo", nil)
 
 	fox := New(WithMiddleware(wrapped))
-	fox.MustHandle(http.MethodGet, "/foo", func(c Context) error {
+	fox.MustHandle(http.MethodGet, "/foo", func(c Context) {
 		invoked = true
-		return nil
 	})
 
 	fox.ServeHTTP(w, r)

--- a/error.go
+++ b/error.go
@@ -7,7 +7,6 @@ package fox
 import (
 	"errors"
 	"fmt"
-	"net/http"
 	"strings"
 )
 
@@ -63,34 +62,4 @@ func (e *RouteConflictError) updateError() string {
 // Unwrap returns the sentinel value ErrRouteConflict.
 func (e *RouteConflictError) Unwrap() error {
 	return e.err
-}
-
-// HTTPError represents an HTTP error with a status code and an optional
-// error message. If no error message is provided, the default error message
-// for the status code will be used.
-type HTTPError struct {
-	Err  error
-	Code int
-}
-
-// Error returns the error message associated with the HTTPError,
-// or the default error message for the status code if none is provided.
-func (e HTTPError) Error() string {
-	if e.Err == nil {
-		return http.StatusText(e.Code)
-	}
-	return e.Err.Error()
-}
-
-// NewHTTPError creates a new HTTPError with the given status code
-// and an optional error message.
-func NewHTTPError(code int, err ...error) HTTPError {
-	var e error
-	if len(err) > 0 {
-		e = err[0]
-	}
-	return HTTPError{
-		Code: code,
-		Err:  e,
-	}
 }

--- a/options.go
+++ b/options.go
@@ -36,16 +36,6 @@ func WithMethodNotAllowed(handler HandlerFunc, m ...MiddlewareFunc) Option {
 	})
 }
 
-// WithRouteError register an ErrorHandlerFunc which is called when an HandlerFunc returns an error.
-// By default, the RouteErrorHandler is used.
-func WithRouteError(handler ErrorHandlerFunc) Option {
-	return optionFunc(func(r *Router) {
-		if handler != nil {
-			r.errRoute = handler
-		}
-	})
-}
-
 // WithMiddleware attaches a global middleware to the router. Middlewares provided will be chained
 // in the order they were added. Note that it does NOT apply the middlewares to the NotFound and MethodNotAllowed handlers.
 func WithMiddleware(m ...MiddlewareFunc) Option {

--- a/options.go
+++ b/options.go
@@ -26,12 +26,12 @@ func WithRouteNotFound(handler HandlerFunc, m ...MiddlewareFunc) Option {
 
 // WithMethodNotAllowed register an HandlerFunc which is called when the request cannot be routed,
 // but the same route exist for other methods. The "Allow" header it automatically set
-// before calling the handler. Set WithHandleMethodNotAllowed to enable this option. By default,
-// the MethodNotAllowedHandler is used.
+// before calling the handler. By default, the MethodNotAllowedHandler is used.
 func WithMethodNotAllowed(handler HandlerFunc, m ...MiddlewareFunc) Option {
 	return optionFunc(func(r *Router) {
 		if handler != nil {
 			r.noMethod = applyMiddleware(m, handler)
+			r.handleMethodNotAllowed = true
 		}
 	})
 }
@@ -45,7 +45,8 @@ func WithMiddleware(m ...MiddlewareFunc) Option {
 }
 
 // WithHandleMethodNotAllowed enable to returns 405 Method Not Allowed instead of 404 Not Found
-// when the route exist for another http verb.
+// when the route exist for another http verb. Note that this option is automatically enabled
+// with WithMethodNotAllowed.
 func WithHandleMethodNotAllowed(enable bool) Option {
 	return optionFunc(func(r *Router) {
 		r.handleMethodNotAllowed = enable

--- a/recovery.go
+++ b/recovery.go
@@ -26,9 +26,9 @@ type RecoveryFunc func(c Context, err any)
 // allowing the http server to handle it as an abort.
 func Recovery(handle RecoveryFunc) MiddlewareFunc {
 	return func(next HandlerFunc) HandlerFunc {
-		return func(c Context) error {
+		return func(c Context) {
 			defer recovery(c, handle)
-			return next(c)
+			next(c)
 		}
 	}
 }


### PR DESCRIPTION
 Returning an error does not fit well when chaining middleware like opentelemetry or prometheus