### PR TITLE
Allow to register middleware for a specific handler scope (404, 405, etc...)

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ routing structure based on user input, configuration changes, or other runtime e
 The current api is not yet stabilize. Breaking changes may occur before `v1.0.0` and will be noted on the release note.
 
 ## Features
-**Runtime update:** Register, update and remove route handler safely at any time without impact on performance. Fox never block while serving
+**Runtime updates:** Register, update and remove route handler safely at any time without impact on performance. Fox never block while serving
 request!
 
 **Wildcard pattern:** Route can be registered using wildcard parameters. The matched path segment can then be easily retrieved by 
@@ -425,11 +425,13 @@ func main() {
 ````
 
 Additionally, `fox.WithScopedMiddleware` option provide a more fine-grained control over where a middleware is applied, such as
-only for 404 or 405 handler. Possible scopes include `fox.RouteHandlers` (regular routes), `fox.NotFoundHandler`, `fox.MethodNotAllowedHandler`, 
+only for 404 or 405 handlers. Possible scopes include `fox.RouteHandlers` (regular routes), `fox.NotFoundHandler`, `fox.MethodNotAllowedHandler`, 
 `RedirectHandler`, and any combination of these.
+
 ````go
 f := fox.New(
-    fox.WithMiddleware(Logger),
+    fox.WithMethodNotAllowed(true),
+    fox.WithScopedMiddleware(fox.RouteHandlers, fox.Recovery(fox.DefaultHandleRecovery), Logger),
     fox.WithScopedMiddleware(fox.NotFoundHandler|fox.MethodNotAllowedHandler, SpecialLogger),
 )
 ````

--- a/README.md
+++ b/README.md
@@ -382,7 +382,7 @@ f.MustHandle(http.MethodGet, "/articles/{id}", func(c fox.Context) {
 
 ## Middleware
 Middlewares can be registered globally using the `fox.WithMiddleware` option. The example below demonstrates how 
-to create and apply automatically a simple logging middleware to all route (including 404, 405, etc...).
+to create and apply automatically a simple logging middleware to all routes (including 404, 405, etc...).
 
 ````go
 package main

--- a/README.md
+++ b/README.md
@@ -424,15 +424,15 @@ func main() {
 }
 ````
 
-Additionally, `fox.WithScopedMiddleware` option provide a more fine-grained control over where a middleware is applied, such as
+Additionally, `fox.WithMiddlewareFor` option provide a more fine-grained control over where a middleware is applied, such as
 only for 404 or 405 handlers. Possible scopes include `fox.RouteHandlers` (regular routes), `fox.NotFoundHandler`, `fox.MethodNotAllowedHandler`, 
 `RedirectHandler`, and any combination of these.
 
 ````go
 f := fox.New(
     fox.WithMethodNotAllowed(true),
-    fox.WithScopedMiddleware(fox.RouteHandlers, fox.Recovery(fox.DefaultHandleRecovery), Logger),
-    fox.WithScopedMiddleware(fox.NotFoundHandler|fox.MethodNotAllowedHandler, SpecialLogger),
+    fox.WithMiddlewareFor(fox.RouteHandlers, fox.Recovery(fox.DefaultHandleRecovery), Logger),
+    fox.WithMiddlewareFor(fox.NotFoundHandler|fox.MethodNotAllowedHandler, SpecialLogger),
 )
 ````
 

--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ routing structure based on user input, configuration changes, or other runtime e
 The current api is not yet stabilize. Breaking changes may occur before `v1.0.0` and will be noted on the release note.
 
 ## Features
-**Routing mutation:** Register, update and remove route handler safely at any time without impact on performance. Fox never block while serving
+**Runtime update:** Register, update and remove route handler safely at any time without impact on performance. Fox never block while serving
 request!
 
 **Wildcard pattern:** Route can be registered using wildcard parameters. The matched path segment can then be easily retrieved by 
@@ -32,9 +32,6 @@ even for complex routing pattern.
 
 **Redirect trailing slashes:** Inspired from [httprouter](https://github.com/julienschmidt/httprouter), the router automatically 
 redirects the client, at no extra cost, if another route match with or without a trailing slash (disable by default). 
-
-**Path auto-correction:** Inspired from [httprouter](https://github.com/julienschmidt/httprouter), the router can remove superfluous path
-elements like `../` or `//` and automatically redirect the client if the cleaned path match a handler (disable by default).
 
 Of course, you can also register custom `NotFound` and `MethodNotAllowed` handlers.
 
@@ -63,9 +60,9 @@ func (h *Greeting) Greet(c fox.Context) {
 }
 
 func main() {
-	r := fox.New(fox.DefaultOptions())
+	f := fox.New(fox.DefaultOptions())
 
-	err := r.Handle(http.MethodGet, "/", func(c fox.Context) {
+	err := f.Handle(http.MethodGet, "/", func(c fox.Context) {
 		_ = c.String(http.StatusOK, "Welcome\n")
 	})
 	if err != nil {
@@ -73,9 +70,9 @@ func main() {
 	}
 
 	h := Greeting{Say: "Hello"}
-	r.MustHandle(http.MethodGet, "/hello/{name}", h.Greet)
+	f.MustHandle(http.MethodGet, "/hello/{name}", h.Greet)
 
-	log.Fatalln(http.ListenAndServe(":8080", r))
+	log.Fatalln(http.ListenAndServe(":8080", f))
 }
 ````
 #### Error handling
@@ -245,9 +242,9 @@ func Action(c fox.Context) {
 }
 
 func main() {
-	r := fox.New()
-	r.MustHandle(http.MethodPost, "/routes/{action}", Action)
-	log.Fatalln(http.ListenAndServe(":8080", r))
+	f := fox.New()
+	f.MustHandle(http.MethodPost, "/routes/{action}", Action)
+	log.Fatalln(http.ListenAndServe(":8080", f))
 }
 ````
 
@@ -282,11 +279,9 @@ func (h *HtmlRenderer) Render(c fox.Context) {
 }
 
 func main() {
-	r := fox.New()
-
-	go Reload(r)
-
-	log.Fatalln(http.ListenAndServe(":8080", r))
+	f := fox.New()
+	go Reload(f)
+	log.Fatalln(http.ListenAndServe(":8080", f))
 }
 
 func Reload(r *fox.Router) {
@@ -373,21 +368,21 @@ articles := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
     _, _ = fmt.Fprintln(w, "get articles")
 })
 
-r := fox.New(fox.DefaultOptions())
-r.MustHandle(http.MethodGet, "/articles", fox.WrapH(httpRateLimiter.RateLimit(articles)))
+f := fox.New(fox.DefaultOptions())
+f.MustHandle(http.MethodGet, "/articles", fox.WrapH(httpRateLimiter.RateLimit(articles)))
 ```
 
 Wrapping an `http.Handler` compatible middleware
 ````go
-r := fox.New(fox.DefaultOptions(), fox.WithMiddleware(fox.WrapM(httpRateLimiter.RateLimit)))
-r.MustHandle(http.MethodGet, "/articles/{id}", func(c fox.Context) {
+f := fox.New(fox.DefaultOptions(), fox.WithMiddleware(fox.WrapM(httpRateLimiter.RateLimit)))
+f.MustHandle(http.MethodGet, "/articles/{id}", func(c fox.Context) {
     _ = c.String(http.StatusOK, "Article id: %s\n", c.Param("id"))
 })
 ````
 
 ## Middleware
 Middlewares can be registered globally using the `fox.WithMiddleware` option. The example below demonstrates how 
-to create and apply automatically a simple logging middleware to all route.
+to create and apply automatically a simple logging middleware to all route (including 404, 405, etc...).
 
 ````go
 package main
@@ -413,9 +408,9 @@ func Logger(next fox.HandlerFunc) fox.HandlerFunc {
 }
 
 func main() {
-	r := fox.New(fox.WithMiddleware(Logger))
+	f := fox.New(fox.WithMiddleware(Logger))
 
-	r.MustHandle(http.MethodGet, "/", func(c fox.Context) {
+	f.MustHandle(http.MethodGet, "/", func(c fox.Context) {
 		resp, err := http.Get("https://api.coindesk.com/v1/bpi/currentprice.json")
 		if err != nil {
 			http.Error(c.Writer(), http.StatusText(http.StatusInternalServerError), http.StatusInternalServerError)
@@ -425,8 +420,18 @@ func main() {
 		_ = c.Stream(http.StatusOK, fox.MIMEApplicationJSON, resp.Body)
 	})
 
-	log.Fatalln(http.ListenAndServe(":8080", r))
+	log.Fatalln(http.ListenAndServe(":8080", f))
 }
+````
+
+Additionally, `fox.WithScopedMiddleware` option provide a more fine-grained control over where a middleware is applied, such as
+only for 404 or 405 handler. Possible scopes include `fox.RouteHandlers` (regular routes), `fox.NotFoundHandler`, `fox.MethodNotAllowedHandler`, 
+`RedirectHandler`, and any combination of these.
+````go
+f := fox.New(
+    fox.WithMiddleware(Logger),
+    fox.WithScopedMiddleware(fox.NotFoundHandler|fox.MethodNotAllowedHandler, SpecialLogger),
+)
 ````
 
 ## Benchmark
@@ -577,3 +582,4 @@ The intention behind these choices is that it can serve as a building block for 
 - [npgall/concurrent-trees](https://github.com/npgall/concurrent-trees): Fox design is largely inspired from Niall Gallagher's Concurrent Trees design.
 - [julienschmidt/httprouter](https://github.com/julienschmidt/httprouter): some feature that implements Fox are inspired from Julien Schmidt's router. Most notably,
 this package uses the optimized [httprouter.Cleanpath](https://github.com/julienschmidt/httprouter/blob/master/path.go) function.
+- The router API is influenced by popular routers such as [gin](https://github.com/gin-gonic/gin) and [https://github.com/labstack/echo](echo).

--- a/fox.go
+++ b/fox.go
@@ -49,8 +49,8 @@ type Router struct {
 }
 
 type middleware struct {
-	m    MiddlewareFunc
-	mode MiddlewareScope
+	m     MiddlewareFunc
+	scope MiddlewareScope
 }
 
 var _ http.Handler = (*Router)(nil)
@@ -533,10 +533,10 @@ func isRemovable(method string) bool {
 	return true
 }
 
-func applyMiddleware(mode MiddlewareScope, mws []middleware, h HandlerFunc) HandlerFunc {
+func applyMiddleware(scope MiddlewareScope, mws []middleware, h HandlerFunc) HandlerFunc {
 	m := h
 	for i := len(mws) - 1; i >= 0; i-- {
-		if mws[i].mode&mode != 0 {
+		if mws[i].scope&scope != 0 {
 			m = mws[i].m(m)
 		}
 	}

--- a/fox_test.go
+++ b/fox_test.go
@@ -1663,7 +1663,7 @@ func TestWithScopedMiddleware(t *testing.T) {
 		}
 	})
 
-	r := New(WithScopedMiddleware(NotFoundHandler, m))
+	r := New(WithMiddlewareFor(NotFoundHandler, m))
 	require.NoError(t, r.Handle(http.MethodGet, "/foo/bar", emptyHandler))
 
 	req := httptest.NewRequest(http.MethodGet, "/foo/bar", nil)

--- a/fox_test.go
+++ b/fox_test.go
@@ -1700,6 +1700,22 @@ func TestWithScopedMiddleware(t *testing.T) {
 	assert.True(t, called)
 }
 
+func TestWithNotFoundHandler(t *testing.T) {
+	notFound := func(c Context) {
+		_ = c.String(http.StatusNotFound, "NOT FOUND\n")
+	}
+
+	f := New(WithNotFoundHandler(notFound))
+	require.NoError(t, f.Handle(http.MethodGet, "/foo", emptyHandler))
+
+	req := httptest.NewRequest(http.MethodGet, "/foo/bar", nil)
+	w := httptest.NewRecorder()
+
+	f.ServeHTTP(w, req)
+	assert.Equal(t, http.StatusNotFound, w.Code)
+	assert.Equal(t, "NOT FOUND\n", w.Body.String())
+}
+
 func TestHas(t *testing.T) {
 	routes := []string{
 		"/foo/bar",

--- a/options.go
+++ b/options.go
@@ -4,6 +4,22 @@
 
 package fox
 
+// MiddlewareScope is a type that represents different scopes for applying middleware.
+type MiddlewareScope uint8
+
+const (
+	// RouteHandlers scope applies middleware only to regular routes registered in the router.
+	RouteHandlers MiddlewareScope = 1 << (8 - 1 - iota)
+	// NotFoundHandler scope applies middleware to the NotFound handler (when a route is not found).
+	NotFoundHandler
+	// MethodNotAllowedHandler scope applies middleware to the MethodNotAllowed handler (when the method is not allowed for the requested route).
+	MethodNotAllowedHandler
+	// RedirectHandler scope applies middleware to the internal redirect handler (for trailing slash and fixed path redirection).
+	RedirectHandler
+	// AllHandlers is a combination of all the above scopes, which means the middleware will be applied to all types of handlers.
+	AllHandlers = RouteHandlers | NotFoundHandler | MethodNotAllowedHandler | RedirectHandler
+)
+
 type Option interface {
 	apply(*Router)
 }
@@ -14,52 +30,55 @@ func (o optionFunc) apply(r *Router) {
 	o(r)
 }
 
-// WithRouteNotFound register an HandlerFunc which is called when no matching route is found.
-// By default, the NotFoundHandler is used.
-func WithRouteNotFound(handler HandlerFunc, m ...MiddlewareFunc) Option {
+// WithNotFoundHandler register an HandlerFunc which is called when no matching route is found.
+// By default, the DefaultNotFoundHandler is used.
+func WithNotFoundHandler(handler HandlerFunc) Option {
 	return optionFunc(func(r *Router) {
 		if handler != nil {
-			r.noRoute = applyMiddleware(m, handler)
+			r.noRoute = handler
 		}
 	})
 }
 
-// WithMethodNotAllowed register an HandlerFunc which is called when the request cannot be routed,
-// but the same route exist for other methods. The "Allow" header it automatically set
-// before calling the handler. By default, the MethodNotAllowedHandler is used.
-func WithMethodNotAllowed(handler HandlerFunc, m ...MiddlewareFunc) Option {
+// WithMethodNotAllowedHandler register an HandlerFunc which is called when the request cannot be routed,
+// but the same route exist for other methods. The "Allow" header it automatically set before calling the
+// handler. By default, the DefaultMethodNotAllowedHandler is used. Note that this option automatically
+// enable WithMethodNotAllowed.
+func WithMethodNotAllowedHandler(handler HandlerFunc) Option {
 	return optionFunc(func(r *Router) {
 		if handler != nil {
-			r.noMethod = applyMiddleware(m, handler)
+			r.noMethod = handler
 			r.handleMethodNotAllowed = true
 		}
 	})
 }
 
 // WithMiddleware attaches a global middleware to the router. Middlewares provided will be chained
-// in the order they were added. Note that it does NOT apply the middlewares to the NotFound and MethodNotAllowed handlers.
+// in the order they were added. Note that this option apply middleware to all handler, including NotFound,
+// MethodNotAllowed and the internal redirect handler.
 func WithMiddleware(m ...MiddlewareFunc) Option {
+	return WithScopedMiddleware(AllHandlers, m...)
+}
+
+// WithScopedMiddleware attaches middleware to the router with a specified scope. Middlewares provided will be chained
+// in the order they were added. The scope parameter determines which types of handlers the middleware will be applied to.
+// Possible scopes include RouteHandlers (regular routes), NotFoundHandler, MethodNotAllowedHandler, RedirectHandler, and any combination of these.
+// Use this option when you need fine-grained control over where the middleware is applied.
+// This api is EXPERIMENTAL and is likely to change in future release.
+func WithScopedMiddleware(scope MiddlewareScope, m ...MiddlewareFunc) Option {
 	return optionFunc(func(r *Router) {
-		r.mws = append(r.mws, m...)
+		for i := range m {
+			r.mws = append(r.mws, middleware{m[i], scope})
+		}
 	})
 }
 
-// WithHandleMethodNotAllowed enable to returns 405 Method Not Allowed instead of 404 Not Found
+// WithMethodNotAllowed enable to returns 405 Method Not Allowed instead of 404 Not Found
 // when the route exist for another http verb. Note that this option is automatically enabled
-// with WithMethodNotAllowed.
-func WithHandleMethodNotAllowed(enable bool) Option {
+// when providing a custom handler with the option WithMethodNotAllowedHandler.
+func WithMethodNotAllowed(enable bool) Option {
 	return optionFunc(func(r *Router) {
 		r.handleMethodNotAllowed = enable
-	})
-}
-
-// WithRedirectFixedPath enable automatic redirection fallback when the current request does not match but
-// another handler is found after cleaning up superfluous path elements (see CleanPath). E.g. /../foo/bar request
-// does not match but /foo/bar would. The client is redirected with a http status code 301 for GET requests
-// and 308 for all other methods.
-func WithRedirectFixedPath(enable bool) Option {
-	return optionFunc(func(r *Router) {
-		r.redirectFixedPath = enable
 	})
 }
 
@@ -77,6 +96,6 @@ func WithRedirectTrailingSlash(enable bool) Option {
 // Note that DefaultOptions push the Recovery middleware to the first position of the middleware chains.
 func DefaultOptions() Option {
 	return optionFunc(func(r *Router) {
-		r.mws = append([]MiddlewareFunc{Recovery(HandleRecovery)}, r.mws...)
+		r.mws = append([]middleware{{Recovery(HandleRecovery), RouteHandlers}}, r.mws...)
 	})
 }

--- a/options.go
+++ b/options.go
@@ -96,6 +96,6 @@ func WithRedirectTrailingSlash(enable bool) Option {
 // Note that DefaultOptions push the Recovery middleware to the first position of the middleware chains.
 func DefaultOptions() Option {
 	return optionFunc(func(r *Router) {
-		r.mws = append([]middleware{{Recovery(HandleRecovery), RouteHandlers}}, r.mws...)
+		r.mws = append([]middleware{{Recovery(DefaultHandleRecovery), RouteHandlers}}, r.mws...)
 	})
 }

--- a/options.go
+++ b/options.go
@@ -10,11 +10,11 @@ type MiddlewareScope uint8
 const (
 	// RouteHandlers scope applies middleware only to regular routes registered in the router.
 	RouteHandlers MiddlewareScope = 1 << (8 - 1 - iota)
-	// NotFoundHandler scope applies middleware to the NotFound handler (when a route is not found).
+	// NotFoundHandler scope applies middleware to the NotFound handler.
 	NotFoundHandler
-	// MethodNotAllowedHandler scope applies middleware to the MethodNotAllowed handler (when the method is not allowed for the requested route).
+	// MethodNotAllowedHandler scope applies middleware to the MethodNotAllowed handler.
 	MethodNotAllowedHandler
-	// RedirectHandler scope applies middleware to the internal redirect handler (for trailing slash and fixed path redirection).
+	// RedirectHandler scope applies middleware to the internal redirect trailing slash handler.
 	RedirectHandler
 	// AllHandlers is a combination of all the above scopes, which means the middleware will be applied to all types of handlers.
 	AllHandlers = RouteHandlers | NotFoundHandler | MethodNotAllowedHandler | RedirectHandler
@@ -57,15 +57,15 @@ func WithMethodNotAllowedHandler(handler HandlerFunc) Option {
 // in the order they were added. Note that this option apply middleware to all handler, including NotFound,
 // MethodNotAllowed and the internal redirect handler.
 func WithMiddleware(m ...MiddlewareFunc) Option {
-	return WithScopedMiddleware(AllHandlers, m...)
+	return WithMiddlewareFor(AllHandlers, m...)
 }
 
-// WithScopedMiddleware attaches middleware to the router with a specified scope. Middlewares provided will be chained
+// WithMiddlewareFor attaches middleware to the router for a specified scope. Middlewares provided will be chained
 // in the order they were added. The scope parameter determines which types of handlers the middleware will be applied to.
-// Possible scopes include RouteHandlers (regular routes), NotFoundHandler, MethodNotAllowedHandler, RedirectHandler, and any combination of these.
-// Use this option when you need fine-grained control over where the middleware is applied.
+// Possible scopes include RouteHandlers (regular routes), NotFoundHandler, MethodNotAllowedHandler, RedirectHandler,
+// and any combination of these. Use this option when you need fine-grained control over where the middleware is applied.
 // This api is EXPERIMENTAL and is likely to change in future release.
-func WithScopedMiddleware(scope MiddlewareScope, m ...MiddlewareFunc) Option {
+func WithMiddlewareFor(scope MiddlewareScope, m ...MiddlewareFunc) Option {
 	return optionFunc(func(r *Router) {
 		for i := range m {
 			r.mws = append(r.mws, middleware{m[i], scope})
@@ -92,7 +92,7 @@ func WithRedirectTrailingSlash(enable bool) Option {
 	})
 }
 
-// DefaultOptions configure the router to use the Recovery middleware.
+// DefaultOptions configure the router to use the Recovery middleware for the RouteHandlers scope.
 // Note that DefaultOptions push the Recovery middleware to the first position of the middleware chains.
 func DefaultOptions() Option {
 	return optionFunc(func(r *Router) {

--- a/tree.go
+++ b/tree.go
@@ -545,10 +545,16 @@ Walk:
 		}
 		if charsMatchedInNodeFound < len(current.key) {
 			// Key end mid-edge
-			// Tsr recommendation: add an extra trailing slash (got an exact match)
 			if !tsr {
-				remainingSuffix := current.key[charsMatchedInNodeFound:]
-				tsr = len(remainingSuffix) == 1 && remainingSuffix[0] == slashDelim
+				if strings.HasSuffix(path, "/") {
+					// Tsr recommendation: remove the extra trailing slash (got an exact match)
+					remainingPrefix := current.key[:charsMatchedInNodeFound]
+					tsr = len(remainingPrefix) == 1 && remainingPrefix[0] == slashDelim
+				} else {
+					// Tsr recommendation: add an extra trailing slash (got an exact match)
+					remainingSuffix := current.key[charsMatchedInNodeFound:]
+					tsr = len(remainingSuffix) == 1 && remainingSuffix[0] == slashDelim
+				}
 			}
 
 			if hasSkpNds {
@@ -583,7 +589,7 @@ Walk:
 		return nil, tsr
 	}
 
-	// Finally incomplete match to middle of ege
+	// Finally incomplete match to middle of edge
 Backtrack:
 	if hasSkpNds {
 		skipped := skipNds.pop()

--- a/tree.go
+++ b/tree.go
@@ -31,7 +31,7 @@ import (
 type Tree struct {
 	ctx   sync.Pool
 	nodes atomic.Pointer[[]*node]
-	mws   []MiddlewareFunc
+	mws   []middleware
 	sync.Mutex
 	maxParams atomic.Uint32
 	maxDepth  atomic.Uint32
@@ -47,7 +47,7 @@ func (t *Tree) Handle(method, path string, handler HandlerFunc) error {
 		return err
 	}
 
-	return t.insert(method, p, catchAllKey, uint32(n), applyMiddleware(t.mws, handler))
+	return t.insert(method, p, catchAllKey, uint32(n), applyMiddleware(RouteHandlers, t.mws, handler))
 }
 
 // Update override an existing handler for the given method and path. If the route does not exist,
@@ -60,7 +60,7 @@ func (t *Tree) Update(method, path string, handler HandlerFunc) error {
 		return err
 	}
 
-	return t.update(method, p, catchAllKey, applyMiddleware(t.mws, handler))
+	return t.update(method, p, catchAllKey, applyMiddleware(RouteHandlers, t.mws, handler))
 }
 
 // Remove delete an existing handler for the given method and path. If the route does not exist, the function


### PR DESCRIPTION
This PR introduces a new feature and removes a previously existing one. The changes include:

1.  A new option, `WithMiddlewareFor`, which provides a more fine-grained control over where a middleware is applied. This can be useful for cases where middlewares should be applied only to specific types of handlers, such as the NotFound or MethodNotAllowed handlers. The `MiddlewareScope`  constants are declared as bitmask flags, which allows to pass any combination of the following scope:

````
fox.RouteHandlers (regular routes)
fox.NotFoundHandler
fox.MethodNotAllowedHandler
fox.RedirectHandler
````

Example usage:
````go
r := fox.New(
    fox.WithMiddlewareFor(fox.RouteHandlers, LoggingMiddleware),
    fox.WithMiddlewareFor(fox.NotFoundHandler|fox.MethodNotAllowedHandler, ErrorLoggingMiddleware),
)
````

In addition, the redirect trailing slash option has been updated to use a `fox.HandlerFunc`, allowing middlewares to be applied to it as well.

2. Removing the `RedirectFixedPath` option, as this functionality can be achieved using a separate middleware.