### PR TITLE
Extend Tree API for manual handler's lookup

### DIFF
--- a/README.md
+++ b/README.md
@@ -438,6 +438,9 @@ f := fox.New(
 )
 ````
 
+### Official middlewares
+* [tigerwill90/otelfox](https://github.com/tigerwill90/otelfox): Distributed tracing with [OpenTelemetry](https://opentelemetry.io/)
+
 ## Benchmark
 The primary goal of Fox is to be a lightweight, high performance router which allow routes modification at runtime.
 The following benchmarks attempt to compare Fox to various popular alternatives, including both fully-featured web frameworks

--- a/README.md
+++ b/README.md
@@ -317,7 +317,7 @@ Note that all read operation on the tree remain lock-free.
 func Upsert(t *fox.Tree, method, path string, handler fox.HandlerFunc) error {
     t.Lock()
     defer t.Unlock()
-    if fox.Has(t, method, path) {
+    if t.Has(method, path) {
         return t.Update(method, path, handler)
     }
     return t.Handle(method, path, handler)

--- a/README.md
+++ b/README.md
@@ -2,6 +2,8 @@
 [![tests](https://github.com/tigerwill90/fox/actions/workflows/tests.yaml/badge.svg)](https://github.com/tigerwill90/fox/actions?query=workflow%3Atests)
 [![Go Report Card](https://goreportcard.com/badge/github.com/tigerwill90/fox)](https://goreportcard.com/report/github.com/tigerwill90/fox)
 [![codecov](https://codecov.io/gh/tigerwill90/fox/branch/master/graph/badge.svg?token=09nfd7v0Bl)](https://codecov.io/gh/tigerwill90/fox)
+![GitHub release (latest SemVer)](https://img.shields.io/github/v/release/tigerwill90/fox)
+![GitHub go.mod Go version](https://img.shields.io/github/go-mod/go-version/tigerwill90/fox)
 # Fox
 Fox is a zero allocation, lightweight, high performance HTTP request router for [Go](https://go.dev/). The main difference with other routers is
 that it supports **mutation on its routing tree while handling request concurrently**. Internally, Fox use a 

--- a/context.go
+++ b/context.go
@@ -63,8 +63,6 @@ type Context interface {
 	Tree() *Tree
 	// Fox returns the Router in use to serve the request.
 	Fox() *Router
-	// SetFox attaches the provided Router instance to the Context.
-	SetFox(fox *Router)
 	// Reset resets the Context to its initial state, attaching the provided Router,
 	// http.ResponseWriter, and *http.Request.
 	Reset(fox *Router, w http.ResponseWriter, r *http.Request)
@@ -224,11 +222,6 @@ func (c *context) Tree() *Tree {
 // Fox returns the Router in use to serve the request.
 func (c *context) Fox() *Router {
 	return c.fox
-}
-
-// SetFox attaches the provided Router instance to the Context.
-func (c *context) SetFox(fox *Router) {
-	c.fox = fox
 }
 
 // Clone returns a copy of the Context that is safe to use after the HandlerFunc returns.

--- a/fox.go
+++ b/fox.go
@@ -74,11 +74,10 @@ func New(opts ...Option) *Router {
 	return r
 }
 
-// NewTree returns a fresh routing Tree which allow to register, update and delete route.
-// It's safe to create multiple Tree concurrently. However, a Tree itself is not thread safe
-// and all its APIs should be run serially. Note that a Tree give direct access to the
-// underlying sync.Mutex.
-// This api is EXPERIMENTAL and is likely to change in future release.
+// NewTree returns a fresh routing Tree. It's safe to create multiple Tree concurrently. However, a Tree itself
+// is not thread-safe and all its APIs that perform write operations should be run serially. Note that a Tree give
+// direct access to the underlying sync.Mutex.
+// This API is EXPERIMENTAL and is likely to change in future release.
 func (fox *Router) NewTree() *Tree {
 	tree := new(Tree)
 	tree.mws = fox.mws
@@ -158,7 +157,7 @@ func (fox *Router) Remove(method, path string) error {
 
 // Has allows to check if the given method and path exactly match a registered route. This function is safe for
 // concurrent use by multiple goroutine and while mutation on Tree are ongoing.
-// This api is EXPERIMENTAL and is likely to change in future release.
+// This API is EXPERIMENTAL and is likely to change in future release.
 func Has(t *Tree, method, path string) bool {
 	nds := *t.nodes.Load()
 	index := findRootNode(method, nds)
@@ -175,7 +174,7 @@ func Has(t *Tree, method, path string) bool {
 
 // Reverse perform a lookup on the tree for the given method and path and return the matching registered route if any.
 // This function is safe for concurrent use by multiple goroutine and while mutation on Tree are ongoing.
-// This api is EXPERIMENTAL and is likely to change in future release.
+// This API is EXPERIMENTAL and is likely to change in future release.
 func Reverse(t *Tree, method, path string) string {
 	nds := *t.nodes.Load()
 	index := findRootNode(method, nds)
@@ -203,7 +202,7 @@ type WalkFunc func(method, path string, handler HandlerFunc) error
 // Walk allow to walk over all registered route in lexicographical order. If the function
 // return the special value SkipMethod, Walk skips the current method. This function is
 // safe for concurrent use by multiple goroutine and while mutation are ongoing.
-// This api is EXPERIMENTAL and is likely to change in future release.
+// This API is EXPERIMENTAL and is likely to change in future release.
 func Walk(tree *Tree, fn WalkFunc) error {
 	nds := *tree.nodes.Load()
 Next:
@@ -279,7 +278,7 @@ func (fox *Router) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 
 	tree := fox.tree.Load()
 	c := tree.ctx.Get().(*context)
-	c.reset(fox, w, r)
+	c.Reset(fox, w, r)
 
 	nds := *tree.nodes.Load()
 	index := findRootNode(r.Method, nds)

--- a/fox.go
+++ b/fox.go
@@ -155,23 +155,6 @@ func (fox *Router) Remove(method, path string) error {
 	return t.Remove(method, path)
 }
 
-// Has allows to check if the given method and path exactly match a registered route. This function is safe for
-// concurrent use by multiple goroutine and while mutation on Tree are ongoing.
-// This API is EXPERIMENTAL and is likely to change in future release.
-func Has(t *Tree, method, path string) bool {
-	nds := *t.nodes.Load()
-	index := findRootNode(method, nds)
-	if index < 0 {
-		return false
-	}
-
-	c := t.ctx.Get().(*context)
-	c.resetNil()
-	n, _ := t.lookup(nds[index], path, c.params, c.skipNds, true)
-	c.Close()
-	return n != nil && n.path == path
-}
-
 // Reverse perform a lookup on the tree for the given method and path and return the matching registered route if any.
 // This function is safe for concurrent use by multiple goroutine and while mutation on Tree are ongoing.
 // This API is EXPERIMENTAL and is likely to change in future release.

--- a/fox_test.go
+++ b/fox_test.go
@@ -1725,38 +1725,7 @@ func TestTree_Lookup(t *testing.T) {
 
 	tree := f.Tree()
 	for _, rte := range githubAPI {
-		req := httptest.NewRequest(rte.method, rte.path, nil)
-		w := httptest.NewRecorder()
-		handler, cc, _ := tree.Lookup(w, req)
-		require.NotNil(t, cc)
-		assert.NotNil(t, handler)
-
-		matches := rx.FindAllString(rte.path, -1)
-		for _, match := range matches {
-			var key string
-			if strings.HasPrefix(match, "*") {
-				key = match[2 : len(match)-1]
-			} else {
-				key = match[1 : len(match)-1]
-			}
-			value := match
-			assert.Equal(t, value, cc.Param(key))
-		}
-
-		cc.Close()
-	}
-}
-
-func TestTree_LookupPath(t *testing.T) {
-	rx := regexp.MustCompile("({|\\*{)[A-z]+[}]")
-	f := New()
-	for _, rte := range githubAPI {
-		require.NoError(t, f.Handle(rte.method, rte.path, emptyHandler))
-	}
-
-	tree := f.Tree()
-	for _, rte := range githubAPI {
-		handler, cc, _ := tree.LookupPath(rte.method, rte.path, false)
+		handler, cc, _ := tree.Lookup(rte.method, rte.path, false)
 		require.NotNil(t, cc)
 		assert.NotNil(t, handler)
 
@@ -2251,13 +2220,13 @@ func ExampleRouter_Tree() {
 // This example demonstrates how to create a custom middleware that cleans the request path and performs a manual
 // lookup on the tree. If the cleaned path matches a registered route, the client is redirected with a 301 status
 // code (Moved Permanently).
-func ExampleTree_LookupPath() {
+func ExampleTree_Lookup() {
 	redirectFixedPath := MiddlewareFunc(func(next HandlerFunc) HandlerFunc {
 		return func(c Context) {
 			req := c.Request()
 
 			cleanedPath := CleanPath(req.URL.Path)
-			handler, cc, _ := c.Tree().LookupPath(req.Method, cleanedPath, true)
+			handler, cc, _ := c.Tree().Lookup(req.Method, cleanedPath, true)
 			// You should always close a non-nil Context.
 			if cc != nil {
 				defer cc.Close()

--- a/tree.go
+++ b/tree.go
@@ -6,7 +6,6 @@ package fox
 
 import (
 	"fmt"
-	"net/http"
 	"sort"
 	"strings"
 	"sync"
@@ -99,40 +98,13 @@ func (t *Tree) Methods() []string {
 	return methods
 }
 
-// Lookup allow to do manual lookup of a route for the given request and return the matched HandlerFunc along with a
-// ContextCloser and trailing slash redirect recommendation. You should always close the ContextCloser if NOT nil by
-// calling cc.Close(). Note that the returned ContextCloser does not have a router attached (use the SetFox method).
-// This function is safe for concurrent use by multiple goroutine and while mutation on Tree are ongoing.
-// This API is EXPERIMENTAL and is likely to change in future release.
-func (t *Tree) Lookup(w http.ResponseWriter, r *http.Request) (handler HandlerFunc, cc ContextCloser, tsr bool) {
-	nds := *t.nodes.Load()
-	index := findRootNode(r.Method, nds)
-	if index < 0 {
-		return
-	}
-
-	path := r.URL.Path
-	if len(r.URL.RawPath) > 0 {
-		path = r.URL.RawPath
-	}
-
-	c := t.ctx.Get().(*context)
-	c.Reset(nil, w, r)
-	n, tsr := t.lookup(nds[index], path, c.params, c.skipNds, false)
-	if n != nil {
-		c.path = n.path
-		return n.handler, c, tsr
-	}
-	return nil, c, tsr
-}
-
-// LookupPath allow to do manual lookup of a route for the given method and path and return the matched HandlerFunc
+// Lookup allow to do manual lookup of a route for the given method and path and return the matched HandlerFunc
 // along with a ContextCloser and trailing slash redirect recommendation. If lazy is set to true, wildcard parameter are
 // not parsed. You should always close the ContextCloser if NOT nil by calling cc.Close(). Note that the returned
 // ContextCloser does not have a router, request and response writer attached (use the Reset method).
 // This function is safe for concurrent use by multiple goroutine and while mutation on Tree are ongoing.
 // This API is EXPERIMENTAL and is likely to change in future release.
-func (t *Tree) LookupPath(method, path string, lazy bool) (handler HandlerFunc, cc ContextCloser, tsr bool) {
+func (t *Tree) Lookup(method, path string, lazy bool) (handler HandlerFunc, cc ContextCloser, tsr bool) {
 	nds := *t.nodes.Load()
 	index := findRootNode(method, nds)
 	if index < 0 {


### PR DESCRIPTION
This PR introduces a new Lookup feature, allowing users to perform manual lookups for handlers based on the request method and path. The Lookup function returns the matched handler, context, and trailing slash recommendation (TSR).

Example: 
````go
package main

import (
	"github.com/tigerwill90/fox"
	"log"
	"net/http"
)

func RedirectFixedPath(next fox.HandlerFunc) fox.HandlerFunc {
	return func(c fox.Context) {
		req := c.Request()

		cleanedPath := fox.CleanPath(req.URL.Path)
		handler, cc, _ := c.Tree().Lookup(req.Method, cleanedPath, true)
		// LookupPath returns a ContextCloser. It's your duty to release the context once done.
		if cc != nil {
			defer cc.Close()
		}

		// 301 redirect and returns without calling the next handler.
		if handler != nil {
			req.URL.Path = cleanedPath
			http.Redirect(c.Writer(), req, req.URL.String(), http.StatusMovedPermanently)
			return
		}

		// Call the next handler (e.g. not found handler)
		next(c)
	}
}

func main() {

	f := fox.New(
		// Only apply the RedirectFixedPath on the NotFoundHandler scope.
		fox.WithMiddlewareFor(fox.NotFoundHandler, RedirectFixedPath),
	)

	f.MustHandle(http.MethodGet, "/foo/bar", func(c fox.Context) {
		_ = c.String(http.StatusOK, "foo bar\n")
	})

	log.Fatalln(http.ListenAndServe(":8080", f))
}
````