### PR TITLE
[BUG] feat(context): update request before calling next

### DIFF
--- a/context.go
+++ b/context.go
@@ -282,6 +282,7 @@ func WrapM(m func(handler http.Handler) http.Handler) MiddlewareFunc {
 	return func(next HandlerFunc) HandlerFunc {
 		return func(c Context) {
 			adapter := m(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				c.SetRequest(r)
 				next(c)
 			}))
 			adapter.ServeHTTP(c.Writer(), c.Request())

--- a/context_test.go
+++ b/context_test.go
@@ -190,7 +190,9 @@ func TestWrapH(t *testing.T) {
 func TestWrapM(t *testing.T) {
 	wrapped := WrapM(func(handler http.Handler) http.Handler {
 		return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-			handler.ServeHTTP(w, r)
+			req := r.Clone(r.Context())
+			req.Header.Set("foo", "bar")
+			handler.ServeHTTP(w, req)
 			_, _ = w.Write([]byte("fox"))
 		})
 	})
@@ -201,6 +203,7 @@ func TestWrapM(t *testing.T) {
 
 	fox := New(WithMiddleware(wrapped))
 	fox.MustHandle(http.MethodGet, "/foo", func(c Context) {
+		assert.Equal(t, "bar", c.Header("foo"))
 		invoked = true
 	})
 


### PR DESCRIPTION
When a wrapped `http.Handler` middleware replace the request, `WrapM` does not update the context request before calling `next`.

````go
func TestWrapM(t *testing.T) {
	wrapped := WrapM(func(handler http.Handler) http.Handler {
		return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
                        // clone and update the request
			req := r.Clone(r.Context())
			req.Header.Set("foo", "bar")
                        // call the next handler with the new request
			handler.ServeHTTP(w, req)
			_, _ = w.Write([]byte("fox"))
		})
	})
	invoked := false

	w := httptest.NewRecorder()
	r := httptest.NewRequest(http.MethodGet, "https://example.com/foo", nil)

	fox := New(WithMiddleware(wrapped))
	fox.MustHandle(http.MethodGet, "/foo", func(c Context) {
                 // We should have the cloned request
		assert.Equal(t, "bar", c.Header("foo"))
		invoked = true
	})

	fox.ServeHTTP(w, r)
	assert.Equal(t, "fox", w.Body.String())
	assert.True(t, invoked)
}
````