### PR TITLE
Dumping response body (optimized multi-writer)

### DIFF
--- a/context.go
+++ b/context.go
@@ -34,6 +34,8 @@ type Context interface {
 	Writer() ResponseWriter
 	// SetWriter sets the ResponseWriter.
 	SetWriter(w ResponseWriter)
+	// TeeResponseTo sets up an additional writer to which the response body will be written.
+	TeeResponseTo(w io.Writer)
 	// Path returns the registered path for the handler.
 	Path() string
 	// Params returns a Params slice containing the matched
@@ -127,6 +129,13 @@ func (c *context) Writer() ResponseWriter {
 // SetWriter sets the ResponseWriter.
 func (c *context) SetWriter(w ResponseWriter) {
 	c.w = w
+}
+
+// TeeResponseTo sets up an additional writer to which the response body will be written.
+func (c *context) TeeResponseTo(w io.Writer) {
+	if w != nil {
+		c.rec.tee = io.MultiWriter(c.rec.ResponseWriter, w)
+	}
 }
 
 // Ctx returns the context associated with the current request.

--- a/fox_test.go
+++ b/fox_test.go
@@ -480,6 +480,26 @@ func benchRouteParallel(b *testing.B, router http.Handler, rte route) {
 	})
 }
 
+/*func BenchmarkDumpBodyFox(b *testing.B) {
+	buf := bytes.NewBuffer(nil)
+	f := New()
+	f.MustHandle(http.MethodGet, "/hello/{name}", func(c Context) {
+		buf.Reset()
+		c.TeeWriter(buf)
+		_, _ = io.WriteString(c.Writer(), c.Param("name"))
+	})
+
+	w := new(mockResponseWriter)
+	r := httptest.NewRequest("GET", "/hello/fox", nil)
+
+	b.ReportAllocs()
+	b.ResetTimer()
+
+	for i := 0; i < b.N; i++ {
+		f.ServeHTTP(w, r)
+	}
+}*/
+
 func BenchmarkStaticAll(b *testing.B) {
 	r := New()
 	for _, route := range staticRoutes {

--- a/response_writer.go
+++ b/response_writer.go
@@ -12,13 +12,42 @@ import (
 	"io"
 	"net"
 	"net/http"
+	"sync"
 )
 
-var _ http.Flusher = (*h1Writer)(nil)
-var _ http.Hijacker = (*h1Writer)(nil)
-var _ io.ReaderFrom = (*h1Writer)(nil)
-var _ http.Pusher = (*h2Writer)(nil)
-var _ http.Flusher = (*h2Writer)(nil)
+var (
+	_ http.Flusher  = (*h1Writer)(nil)
+	_ http.Hijacker = (*h1Writer)(nil)
+	_ io.ReaderFrom = (*h1Writer)(nil)
+)
+
+var (
+	_ io.Writer       = (*h1MultiWriter)(nil)
+	_ io.StringWriter = (*h1MultiWriter)(nil)
+	_ http.Flusher    = (*h1MultiWriter)(nil)
+	_ http.Hijacker   = (*h1MultiWriter)(nil)
+	_ io.ReaderFrom   = (*h1MultiWriter)(nil)
+)
+
+var (
+	_ http.Pusher  = (*h2Writer)(nil)
+	_ http.Flusher = (*h2Writer)(nil)
+)
+
+var (
+	_ io.Writer       = (*h2MultiWriter)(nil)
+	_ io.StringWriter = (*h2MultiWriter)(nil)
+	_ http.Flusher    = (*h2MultiWriter)(nil)
+	_ http.Pusher     = (*h2MultiWriter)(nil)
+	_ http.Flusher    = (*h2MultiWriter)(nil)
+)
+
+var copyBufPool = sync.Pool{
+	New: func() any {
+		b := make([]byte, 32*1024)
+		return &b
+	},
+}
 
 // ResponseWriter extends http.ResponseWriter and provides
 // methods to retrieve the recorded status code, written state, and response size.
@@ -42,7 +71,6 @@ const notWritten = -1
 
 type recorder struct {
 	http.ResponseWriter
-	tee    io.Writer
 	size   int
 	status int
 }
@@ -51,7 +79,6 @@ func (r *recorder) reset(w http.ResponseWriter) {
 	r.ResponseWriter = w
 	r.size = notWritten
 	r.status = http.StatusOK
-	r.tee = nil
 }
 
 func (r *recorder) Status() int {
@@ -84,12 +111,6 @@ func (r *recorder) Write(buf []byte) (n int, err error) {
 		r.ResponseWriter.WriteHeader(r.status)
 	}
 
-	if r.tee != nil {
-		n, err = r.tee.Write(buf)
-		r.size += n
-		return
-	}
-
 	n, err = r.ResponseWriter.Write(buf)
 	r.size += n
 	return
@@ -99,12 +120,6 @@ func (r *recorder) WriteString(s string) (n int, err error) {
 	if !r.Written() {
 		r.size = 0
 		r.ResponseWriter.WriteHeader(r.status)
-	}
-
-	if r.tee != nil {
-		n, err = io.WriteString(r.tee, s)
-		r.size += n
-		return
 	}
 
 	n, err = io.WriteString(r.ResponseWriter, s)
@@ -161,12 +176,13 @@ type h1Writer struct {
 	*recorder
 }
 
-func (w h1Writer) ReadFrom(r io.Reader) (n int64, err error) {
-	rf := w.recorder.ResponseWriter.(io.ReaderFrom)
+func (w h1Writer) ReadFrom(src io.Reader) (n int64, err error) {
 	if !w.recorder.Written() {
 		w.recorder.size = 0
 	}
-	n, err = rf.ReadFrom(r)
+
+	rf := w.recorder.ResponseWriter.(io.ReaderFrom)
+	n, err = rf.ReadFrom(src)
 	w.recorder.size += int(n)
 	return
 }
@@ -211,3 +227,165 @@ func (n noopWriter) Write([]byte) (int, error) {
 }
 
 func (n noopWriter) WriteHeader(int) {}
+
+type h1MultiWriter struct {
+	*recorder
+	writers *[]io.Writer
+}
+
+func (w h1MultiWriter) Write(p []byte) (n int, err error) {
+	n, err = w.recorder.Write(p)
+	if err != nil {
+		return
+	}
+	if n != len(p) {
+		err = io.ErrShortWrite
+		return
+	}
+
+	for _, writer := range *w.writers {
+		n, err = writer.Write(p)
+		if err != nil {
+			return
+		}
+		if n != len(p) {
+			err = io.ErrShortWrite
+			return
+		}
+	}
+	return len(p), nil
+}
+func (w h1MultiWriter) WriteString(s string) (n int, err error) {
+	var p []byte // lazily initialized if/when needed
+	n, err = w.recorder.WriteString(s)
+	if err != nil {
+		return
+	}
+	if n != len(s) {
+		err = io.ErrShortWrite
+		return
+	}
+
+	for _, writer := range *w.writers {
+		if sw, ok := writer.(io.StringWriter); ok {
+			n, err = sw.WriteString(s)
+		} else {
+			if p == nil {
+				p = []byte(s)
+			}
+			n, err = writer.Write(p)
+		}
+		if err != nil {
+			return
+		}
+		if n != len(s) {
+			err = io.ErrShortWrite
+			return
+		}
+	}
+	return len(s), nil
+}
+
+func (w h1MultiWriter) Flush() {
+	if !w.recorder.Written() {
+		w.recorder.size = 0
+	}
+	w.recorder.ResponseWriter.(http.Flusher).Flush()
+
+	for _, writer := range *w.writers {
+		if f, ok := writer.(http.Flusher); ok {
+			f.Flush()
+		}
+	}
+}
+
+func (w h1MultiWriter) ReadFrom(src io.Reader) (n int64, err error) {
+	bufp := copyBufPool.Get().(*[]byte)
+	buf := *bufp
+	n, err = io.CopyBuffer(w, src, buf)
+	copyBufPool.Put(bufp)
+	return
+}
+
+func (w h1MultiWriter) Hijack() (net.Conn, *bufio.ReadWriter, error) {
+	if !w.recorder.Written() {
+		w.recorder.size = 0
+	}
+
+	return w.recorder.ResponseWriter.(http.Hijacker).Hijack()
+}
+
+type h2MultiWriter struct {
+	*recorder
+	writers *[]io.Writer
+}
+
+func (w h2MultiWriter) Write(p []byte) (n int, err error) {
+	n, err = w.recorder.Write(p)
+	if err != nil {
+		return
+	}
+	if n != len(p) {
+		err = io.ErrShortWrite
+		return
+	}
+
+	for _, writer := range *w.writers {
+		n, err = writer.Write(p)
+		if err != nil {
+			return
+		}
+		if n != len(p) {
+			err = io.ErrShortWrite
+			return
+		}
+	}
+	return len(p), nil
+}
+func (w h2MultiWriter) WriteString(s string) (n int, err error) {
+	var p []byte // lazily initialized if/when needed
+	n, err = w.recorder.WriteString(s)
+	if err != nil {
+		return
+	}
+	if n != len(s) {
+		err = io.ErrShortWrite
+		return
+	}
+
+	for _, writer := range *w.writers {
+		if sw, ok := writer.(io.StringWriter); ok {
+			n, err = sw.WriteString(s)
+		} else {
+			if p == nil {
+				p = []byte(s)
+			}
+			n, err = writer.Write(p)
+		}
+		if err != nil {
+			return
+		}
+		if n != len(s) {
+			err = io.ErrShortWrite
+			return
+		}
+	}
+	return len(s), nil
+}
+
+func (w h2MultiWriter) Flush() {
+	if !w.recorder.Written() {
+		w.recorder.size = 0
+	}
+	w.recorder.ResponseWriter.(http.Flusher).Flush()
+
+	for _, writer := range *w.writers {
+		if f, ok := writer.(http.Flusher); ok {
+			f.Flush()
+		}
+	}
+}
+
+func (w h2MultiWriter) Push(target string, opts *http.PushOptions) error {
+	return w.recorder.ResponseWriter.(http.Pusher).Push(target, opts)
+}

--- a/tree.go
+++ b/tree.go
@@ -6,6 +6,7 @@ package fox
 
 import (
 	"fmt"
+	"io"
 	"sort"
 	"strings"
 	"sync"
@@ -710,9 +711,11 @@ STOP:
 func (t *Tree) allocateContext() *context {
 	params := make(Params, 0, t.maxParams.Load())
 	skipNds := make(skippedNodes, 0, t.maxDepth.Load())
+	mw := make([]io.Writer, 0, 1)
 	return &context{
 		params:  &params,
 		skipNds: &skipNds,
+		mw:      &mw,
 		// This is a read only value, no reset, it's always the
 		// owner of the pool.
 		tree: t,


### PR DESCRIPTION
### Abstract
This proposal introduces a new feature in the Fox Router to enable users to dump the HTTP response body while writing to the `ResponseWriter`. The feature is designed to be efficient, versatile, and compatible with existing `http.ResponseWriter` interfaces like `http.Hijacker`, `http.Flusher,` etc. To achieve this, the proposal introduces a new API method and constructs custom multiwriters compatible with HTTP/1 and HTTP/2 interface.

### Introduction
In the current system, there is no direct way to dump the HTTP response body while writing to the `ResponseWriter`. This feature can be useful in several scenarios, such as debugging, logging, testing, and monitoring. This proposal aims to fill this gap.

### Proposal
The proposed change introduces a new API method:
````go
type Context inteface {
    // TeeWriter set up one or more additional writers (sink) to which the response body will be written.
    TeeWriter(sink io.Writer,sinks ...io.Writer) {...}
}
````

When invoked, this method sets up one or more additional writers (sinks) to which the response body will be written. These writers are typically `io.Writer` implementations like `bytes.Buffer`. Depending on the HTTP protocol in use, the router creates either an `h1MultiWriter` or an `h2MultiWriter` that ensures compatibility with existing interfaces like `ReaderFrom` or `Pusher`.

The `h1MultiWriter` and `h2MultiWriter` are custom implementations of  `io.MultiWriter`. They handle writing to multiple writers, including the original `ResponseWriter` and any additional writers specified by the user. When a write operation occurs, it writes to all these writers. Similarly, when a flush operation is invoked, it flushes all writers that implement the `http.Flusher` interface. For HTTP/2, it also handles server push operations.

This design ensures that the new feature works efficiently and seamlessly with the existing system, without breaking any current functionality or compatibility.

### Performance Considerations
This feature is designed with performance in mind. When the `TeeWriter` feature is not used, there is no performance impact on the router's operation. The creation of the custom multiwriters only occurs when the `TeeWriter` method is invoked with one or more writers. This ensures that the overhead of managing multiple writers is only incurred when the feature is actively used.

For example, the following preliminary benchmark offers a comparison between Echo's `ResponseBodyDumper` middleware and the proposed `TeeWriter` method.

````
goos: linux
goarch: amd64
pkg: github.com/tigerwill90/fox
cpu: Intel(R) Core(TM) i9-9900K CPU @ 3.60GHz
BenchmarkDumpBodyFox-16          8429208               139.8 ns/op            16 B/op          1 allocs/op
BenchmarkDumpBodyEcho-16         4582627               308.4 ns/op           128 B/op          5 allocs/op
````

### Flexibility and Use Cases
The `TeeWriter` method is extremely flexible and can be used in various ways to suit different use cases. It can be used in a middleware, providing a consistent body dumping behavior across multiple routes, or it can be used on a per-route basis, allowing for fine-grained control over which routes have the body dumping feature enabled.

Furthermore, because the user provides the `io.Writer` to the `TeeWriter` method, they have complete control over the management of these writers. For instance, they could use a `sync.Pool` of writers to efficiently reuse memory across multiple requests, or they could use different writer implementations for different routes or conditions. This allows users to tailor the body dumping behavior to their specific needs and constraints.

### Backward Compatibility
The proposed change is fully backward compatible. It introduces a new API method and does not modify or remove any existing APIs. Users who do not use the new feature will not experience any change in the router's behavior.


### Conclusion
The proposed feature enhances the router functionality by allowing users to dump the HTTP response body while writing to the `ResponseWriter`. It is designed to be efficient, flexible, and reasonably compatible with existing `http.ResponseWriter` interfaces. The feature can be used as needed, without any performance impact when not in use. With the user's freedom to provide their own `io.Writer`, they can implement the feature in a way that best suits their specific use cases, whether it be efficient memory usage with `sync.Pool`, or different writer implementations for different routes or conditions. This feature will be a valuable tool for debugging, testing, logging, and monitoring HTTP response data.

