### PR TITLE
Improve documentation for custom response writer implementation 

### DIFF
--- a/README.md
+++ b/README.md
@@ -367,7 +367,7 @@ func handle(c fox.Context) {
 Fox itself implements the `http.Handler` interface which make easy to chain any compatible middleware before the router. Moreover, the router
 provides convenient `fox.WrapF`, `fox.WrapH` and `fox.WrapM` adapter to be use with `http.Handler`.
 
-The route parameters are being accessed by the wrapped handler through the `context.Context` when the adapter `fox.WrapF` and `fox.WrapH` are used.
+The route parameters can be accessed by the wrapped handler through the `context.Context` when the adapters `fox.WrapF` and `fox.WrapH` are used.
 
 Wrapping an `http.Handler`
 ```go
@@ -387,6 +387,13 @@ f.MustHandle(http.MethodGet, "/articles/{id}", func(c fox.Context) {
     _ = c.String(http.StatusOK, "Article id: %s\n", c.Param("id"))
 })
 ````
+
+### Custom http.ResponseWriter Implementations
+When using custom `http.ResponseWriter` implementations, it's important to ensure that these implementations expose the 
+required http interfaces. For HTTP/1.x requests, Fox expects the `http.ResponseWriter` to implement the `http.Flusher`, 
+`http.Hijacker`, and `io.ReaderFrom` interfaces. For HTTP/2 requests, the `http.ResponseWriter` should implement the 
+`http.Flusher` and `http.Pusher` interfaces. Fox will invoke these methods **without any prior assertion**.
+
 
 ## Middleware
 Middlewares can be registered globally using the `fox.WithMiddleware` option. The example below demonstrates how 

--- a/fox.go
+++ b/fox.go
@@ -253,6 +253,13 @@ func defaultOptionsHandler(c Context) {
 	c.Writer().WriteHeader(http.StatusOK)
 }
 
+// ServeHTTP is the main entry point to serve a request. It handles all incoming HTTP requests and dispatches them
+// to the appropriate handler function based on the request's method and path.
+//
+// It expects the http.ResponseWriter provided to implement the http.Flusher, http.Hijacker, and io.ReaderFrom
+// interfaces for HTTP/1.x requests and the http.Flusher and http.Pusher interfaces for HTTP/2 requests.
+// If a custom response writer is used, it is critical to ensure that these methods are properly exposed as Fox
+// will invoke them without any prior assertion.
 func (fox *Router) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 
 	var (

--- a/params.go
+++ b/params.go
@@ -6,8 +6,10 @@ package fox
 
 import netcontext "context"
 
+type ctxKey struct{}
+
 // paramsKey is the key that holds the Params in a context.Context.
-var paramsKey = struct{}{}
+var paramsKey = ctxKey{}
 
 type Param struct {
 	Key   string
@@ -44,9 +46,9 @@ func (p Params) Clone() Params {
 	return cloned
 }
 
-// ParamsFromContext allows extracting params from the given context.
+// ParamsFromContext is a helper to retrieve params from context when a http.Handler
+// is registered using WrapF or WrapH.
 func ParamsFromContext(ctx netcontext.Context) Params {
 	p, _ := ctx.Value(paramsKey).(Params)
-
 	return p
 }


### PR DESCRIPTION
Just a few documentation enchancement and providing guidance on implementing custom `http.ResponseWriter` with the necessary http interfaces.