### PR TITLE
fix(auto-options): set the path parameter for the matched route

### DIFF
--- a/fox.go
+++ b/fox.go
@@ -323,6 +323,8 @@ NoMethodFallback:
 				if n, _ := tree.lookup(nds[i], target, c.params, c.skipNds, true); n != nil {
 					if sb.Len() > 0 {
 						sb.WriteString(", ")
+					} else {
+						c.path = n.path
 					}
 					sb.WriteString(nds[i].key)
 				}

--- a/fox_test.go
+++ b/fox_test.go
@@ -1760,6 +1760,7 @@ func TestRouterWithAutomaticOptions(t *testing.T) {
 
 func TestRouterWithOptionsHandler(t *testing.T) {
 	f := New(WithOptionsHandler(func(c Context) {
+		assert.Equal(t, "/foo/bar", c.Path())
 		c.Writer().WriteHeader(http.StatusNoContent)
 	}))
 


### PR DESCRIPTION
This PR addresses a bug in the automatic OPTIONS replies feature. Previously, the `fox.Context` path (`c.Path()`) parameter was not being set for the matched route, resulting in an incorrect or missing path during the handling of OPTIONS requests.

The fix involves setting `c.path ` to `n.path` within the for loop that iterates over the nodes of the current tree. This ensures that the context path is correctly assigned (only once) for the matched route when processing OPTIONS requests.

Here's the key part of the fix:

````go
for i := 0; i < len(nds); i++ {
	if n, _ := tree.lookup(nds[i], target, c.params, c.skipNds, true); n != nil {
		if sb.Len() > 0 {
			sb.WriteString(", ")
		} else {
			c.path = n.path // Context path is now correctly set
		}
		sb.WriteString(nds[i].key)
	}
}
````

Tests have been updated accordingly.