### PR TITLE
Allow overlapping catch-all and param segment

### DIFF
--- a/README.md
+++ b/README.md
@@ -135,7 +135,14 @@ Patter /src/file=*{path}
 
 #### Priority rules
 Routes are prioritized based on specificity, with static segments taking precedence over wildcard segments.
-A wildcard segment (named parameter or catch all) can only overlap with static segments, for the same HTTP method.
+
+The following rules apply:
+
+- Static segments are always evaluated first.
+- A named parameter can only overlap with a catch-all parameter or static segments.
+- A catch-all parameter can only overlap with a named parameter or static segments.
+- When a named parameter overlaps with a catch-all parameter, the named parameter is evaluated first.
+
 For instance, `GET /users/{id}` and `GET /users/{name}/profile` cannot coexist, as the `{id}` and `{name}` segments 
 are overlapping. These limitations help to minimize the number of branches that need to be evaluated in order to find 
 the right match, thereby maintaining high-performance routing.
@@ -147,6 +154,13 @@ GET /users/{id}
 GET /users/{id}/emails
 GET /users/{id}/{actions}
 POST /users/{name}/emails
+````
+
+Additionally, let's consider an example to illustrate the prioritization:
+````
+GET /fs/avengers.txt    #1 => match /fs/avengers.txt
+GET /fs/{filename}      #2 => match /fs/ironman.txt
+GET /fs/*{filepath}     #3 => match /fs/avengers/ironman.txt
 ````
 
 #### Warning about context

--- a/README.md
+++ b/README.md
@@ -28,9 +28,8 @@ name. Due to Fox design, wildcard route are cheap and scale really well.
 **Get the current route:** You can easily retrieve the route of the matched request. This actually makes it easier to integrate
 observability middleware like open telemetry.
 
-**Only explicit matches:**  A request can only match exactly one route or no route at all. Fox strikes a balance between routing flexibility,
-performance and clarity by enforcing clear priority rules, ensuring that there are no unintended matches and maintaining high performance 
-even for complex routing pattern.
+**Flexible routing:**  Fox strikes a balance between routing flexibility, performance and clarity by enforcing clear 
+priority rules, ensuring that there are no unintended matches and maintaining high performance even for complex routing pattern.
 
 **Redirect trailing slashes:** Inspired from [httprouter](https://github.com/julienschmidt/httprouter), the router automatically 
 redirects the client, at no extra cost, if another route match with or without a trailing slash.

--- a/README.md
+++ b/README.md
@@ -633,6 +633,7 @@ BenchmarkPat_GithubAll               424           2899405 ns/op         1843501
 ## Road to v1
 - [x] [Update route syntax](https://github.com/tigerwill90/fox/pull/10#issue-1643728309) @v0.6.0
 - [x] [Route overlapping](https://github.com/tigerwill90/fox/pull/9#issue-1642887919) @v0.7.0
+- [x] [Route overlapping (catch-all and params)](https://github.com/tigerwill90/fox/pull/24#issue-1784686061) @v0.10.0
 - [ ] Improving performance and polishing
 
 ## Contributions

--- a/context.go
+++ b/context.go
@@ -40,7 +40,7 @@ type Context interface {
 	// Therefore, while asserting interfaces like http.Hijacker will not fail, invoking Hijack method will panic if the
 	// underlying ResponseWriter does not implement this interface.
 	//
-	// To facilitate testing with e.g. httptest.Recorder, use the WrapTestContext helper function which only exposes the
+	// To facilitate testing with e.g. httptest.Recorder, use the WrapTestContextFlusher helper function which only exposes the
 	// http.Flusher interface for the ResponseWriter.
 	Writer() ResponseWriter
 	// SetWriter sets the ResponseWriter.

--- a/context_test.go
+++ b/context_test.go
@@ -371,7 +371,7 @@ func TestContext_TeeWriter_flusher(t *testing.T) {
 			t.Parallel()
 			f := New()
 			dumper := bytes.NewBuffer(nil)
-			require.NoError(t, f.Handle(http.MethodGet, "/foo", WrapTestContext(tc.handler(dumper))))
+			require.NoError(t, f.Handle(http.MethodGet, "/foo", WrapTestContextFlusher(tc.handler(dumper))))
 
 			srv := httptest.NewServer(f)
 			defer srv.Close()

--- a/error.go
+++ b/error.go
@@ -17,7 +17,6 @@ var (
 	ErrInvalidRoute            = errors.New("invalid route")
 	ErrDiscardedResponseWriter = errors.New("discarded response writer")
 	ErrInvalidRedirectCode     = errors.New("invalid redirect code")
-	ErrInvalidCtxParams        = errors.New("unable to get params from context")
 )
 
 // RouteConflictError is a custom error type used to represent conflicts when

--- a/fox_test.go
+++ b/fox_test.go
@@ -1068,17 +1068,17 @@ func TestInsertConflict(t *testing.T) {
 				{path: "/foo/baz", wantErr: nil, wantMatch: nil},
 				{path: "/foo/bar", wantErr: nil, wantMatch: nil},
 				{path: "/foo/{id}", wantErr: nil, wantMatch: nil},
-				{path: "/foo/*{args}", wantErr: ErrRouteConflict, wantMatch: []string{"/foo/{id}"}},
+				{path: "/foo/*{args}", wantErr: nil, wantMatch: nil},
 				{path: "/avengers/ironman/{power}", wantErr: nil, wantMatch: nil},
 				{path: "/avengers/{id}/bar", wantErr: nil, wantMatch: nil},
 				{path: "/avengers/{id}/foo", wantErr: nil, wantMatch: nil},
-				{path: "/avengers/*{args}", wantErr: ErrRouteConflict, wantMatch: []string{"/avengers/{id}/bar", "/avengers/{id}/foo"}},
+				{path: "/avengers/*{args}", wantErr: nil, wantMatch: nil},
 				{path: "/fox/", wantErr: nil, wantMatch: nil},
 				{path: "/fox/*{args}", wantErr: ErrRouteExist, wantMatch: nil},
 			},
 		},
 		{
-			name: "incomplete match to end of edge conflicts",
+			name: "no conflict for incomplete match to end of edge",
 			routes: []struct {
 				wantErr   error
 				path      string
@@ -1087,27 +1087,27 @@ func TestInsertConflict(t *testing.T) {
 				{path: "/foo/bar", wantErr: nil, wantMatch: nil},
 				{path: "/foo/baz", wantErr: nil, wantMatch: nil},
 				{path: "/foo/*{args}", wantErr: nil, wantMatch: nil},
-				{path: "/foo/{id}", wantErr: ErrRouteConflict, wantMatch: []string{"/foo/*{args}"}},
+				{path: "/foo/{id}", wantErr: nil, wantMatch: nil},
 			},
 		},
 		{
-			name: "key match mid-edge conflict",
+			name: "no conflict for key match mid-edge",
 			routes: []struct {
 				wantErr   error
 				path      string
 				wantMatch []string
 			}{
 				{path: "/foo/{id}", wantErr: nil, wantMatch: nil},
-				{path: "/foo/*{args}", wantErr: ErrRouteConflict, wantMatch: []string{"/foo/{id}"}},
+				{path: "/foo/*{args}", wantErr: nil, wantMatch: nil},
 				{path: "/foo/a*{args}", wantErr: nil, wantMatch: nil},
 				{path: "/foo*{args}", wantErr: nil, wantMatch: nil},
 				{path: "/john{doe}", wantErr: nil, wantMatch: nil},
-				{path: "/john*{doe}", wantErr: ErrRouteConflict, wantMatch: []string{"/john{doe}"}},
+				{path: "/john*{doe}", wantErr: nil, wantMatch: nil},
 				{path: "/john/{doe}", wantErr: nil, wantMatch: nil},
 				{path: "/joh{doe}", wantErr: nil, wantMatch: nil},
 				{path: "/avengers/{id}/foo", wantErr: nil, wantMatch: nil},
 				{path: "/avengers/{id}/bar", wantErr: nil, wantMatch: nil},
-				{path: "/avengers/*{args}", wantErr: ErrRouteConflict, wantMatch: []string{"/avengers/{id}/bar", "/avengers/{id}/foo"}},
+				{path: "/avengers/*{args}", wantErr: nil, wantMatch: nil},
 			},
 		},
 		{
@@ -2392,24 +2392,30 @@ func ExampleTree_Lookup() {
 	})
 }
 
-/*func TestX(t *testing.T) {
+// path: GET
+//
+//	path: /users/ [paramIdx=0] [catchAll] [leaf=/users/*{any}]
+//	    path: {id}/ [paramIdx=1]
+//	        path: email [leaf=/users/{id}/email]
+//	        path: {action} [leaf=/users/{id}/{action}]
+func TestX(t *testing.T) {
 	f := New()
-	f.MustHandle(http.MethodGet, "/foo/baz", func(c Context) {
+	f.MustHandle(http.MethodGet, "/users/{id}/email", func(c Context) {
 		fmt.Println(c.Path(), c.Params())
 	})
-	f.MustHandle(http.MethodGet, "/foo/*{any}", func(c Context) {
+	f.MustHandle(http.MethodGet, "/users/{id}/{action}", func(c Context) {
 		fmt.Println(c.Path(), c.Params())
 	})
-	f.MustHandle(http.MethodGet, "/foo/", func(c Context) {
+	f.MustHandle(http.MethodGet, "/users/*{any}", func(c Context) {
 		fmt.Println(c.Path(), c.Params())
 	})
 
 	nds := *f.tree.Load().nodes.Load()
 	fmt.Println(nds[0])
 
-	req := httptest.NewRequest(http.MethodGet, "/foo/d/c", nil)
+	req := httptest.NewRequest(http.MethodGet, "/users/123/orders/5", nil)
 	w := httptest.NewRecorder()
 
 	f.ServeHTTP(w, req)
 	assert.Equal(t, http.StatusOK, w.Code)
-}*/
+}

--- a/fox_test.go
+++ b/fox_test.go
@@ -2391,3 +2391,25 @@ func ExampleTree_Lookup() {
 		_ = c.String(http.StatusOK, "foo bar")
 	})
 }
+
+/*func TestX(t *testing.T) {
+	f := New()
+	f.MustHandle(http.MethodGet, "/foo/baz", func(c Context) {
+		fmt.Println(c.Path(), c.Params())
+	})
+	f.MustHandle(http.MethodGet, "/foo/*{any}", func(c Context) {
+		fmt.Println(c.Path(), c.Params())
+	})
+	f.MustHandle(http.MethodGet, "/foo/", func(c Context) {
+		fmt.Println(c.Path(), c.Params())
+	})
+
+	nds := *f.tree.Load().nodes.Load()
+	fmt.Println(nds[0])
+
+	req := httptest.NewRequest(http.MethodGet, "/foo/d/c", nil)
+	w := httptest.NewRecorder()
+
+	f.ServeHTTP(w, req)
+	assert.Equal(t, http.StatusOK, w.Code)
+}*/

--- a/helpers.go
+++ b/helpers.go
@@ -20,11 +20,12 @@ func NewTestContextOnly(fox *Router, w http.ResponseWriter, r *http.Request) Con
 	return newTextContextOnly(fox, w, r)
 }
 
-// WrapTestContext method is a helper function provided for testing purposes. It wraps the provided HandlerFunc,
-// returning a new HandlerFunc that only exposes the http.Flusher interface of the ResponseWriter. This is useful when
+// WrapTestContextFlusher method is a helper function provided for testing purposes. It wraps the provided HandlerFunc,
+// returning a new HandlerFunc that only exposes the http.Flusher interface of the ResponseWriter. This is useful for
 // testing implementations that rely on interface assertions with e.g. httptest.Recorder, since its only
 // supports the http.Flusher interface.
-func WrapTestContext(next HandlerFunc) HandlerFunc {
+// This API is EXPERIMENTAL and is likely to change in future release.
+func WrapTestContextFlusher(next HandlerFunc) HandlerFunc {
 	return func(c Context) {
 		c.SetWriter(onlyFlushWriter{c.Writer()})
 		next(c)

--- a/helpers_test.go
+++ b/helpers_test.go
@@ -19,12 +19,12 @@ func TestWrapFlushWriter(t *testing.T) {
 	buf := bytes.NewBuffer(nil)
 
 	f := New()
-	f.MustHandle(http.MethodGet, "/foo", WrapTestContext(func(c Context) {
-		flusher, ok := c.Writer().(http.Flusher)
+	f.MustHandle(http.MethodGet, "/foo", WrapTestContextFlusher(func(c Context) {
+		_, ok := c.Writer().(http.Flusher)
 		require.True(t, ok)
 
 		c.TeeWriter(buf)
-		flusher, ok = c.Writer().(http.Flusher)
+		flusher, ok := c.Writer().(http.Flusher)
 		require.True(t, ok)
 
 		n, err := c.Writer().Write([]byte("foo"))
@@ -62,11 +62,11 @@ func TestNewTestContext(t *testing.T) {
 
 	buf := bytes.NewBuffer(nil)
 
-	flusher, ok := c.Writer().(http.Flusher)
+	_, ok := c.Writer().(http.Flusher)
 	require.True(t, ok)
 
 	c.TeeWriter(buf)
-	flusher, ok = c.Writer().(http.Flusher)
+	flusher, ok := c.Writer().(http.Flusher)
 	require.True(t, ok)
 
 	n, err := c.Writer().Write([]byte("foo"))

--- a/node.go
+++ b/node.go
@@ -216,6 +216,7 @@ func (n *skippedNodes) pop() skippedNode {
 type skippedNode struct {
 	node      *node
 	pathIndex int
+	paramCnt  uint32
 	seen      bool
 }
 

--- a/node.go
+++ b/node.go
@@ -216,6 +216,7 @@ func (n *skippedNodes) pop() skippedNode {
 type skippedNode struct {
 	node      *node
 	pathIndex int
+	seen      bool
 }
 
 func appendCatchAll(path, catchAllKey string) string {

--- a/recovery_test.go
+++ b/recovery_test.go
@@ -1,0 +1,88 @@
+package fox
+
+import (
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"net"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"syscall"
+	"testing"
+)
+
+func TestAbortHandler(t *testing.T) {
+	m := Recovery(func(c Context, err any) {
+		c.Writer().WriteHeader(http.StatusInternalServerError)
+		_, _ = c.Writer().Write([]byte(err.(error).Error()))
+	})
+
+	r := New(WithMiddleware(m))
+
+	h := func(c Context) {
+		func() { panic(http.ErrAbortHandler) }()
+		_ = c.String(200, "foo")
+	}
+
+	require.NoError(t, r.Tree().Handle(http.MethodPost, "/", h))
+	req := httptest.NewRequest(http.MethodPost, "/", nil)
+	w := httptest.NewRecorder()
+
+	defer func() {
+		val := recover()
+		require.NotNil(t, val)
+		err := val.(error)
+		require.NotNil(t, err)
+		assert.ErrorIs(t, err, http.ErrAbortHandler)
+	}()
+	r.ServeHTTP(w, req)
+}
+
+func TestRecoveryMiddleware(t *testing.T) {
+	m := Recovery(func(c Context, err any) {
+		c.Writer().WriteHeader(http.StatusInternalServerError)
+		_, _ = c.Writer().Write([]byte(err.(string)))
+	})
+
+	r := New(WithMiddleware(m))
+
+	const errMsg = "unexpected error"
+	h := func(c Context) {
+		func() { panic(errMsg) }()
+		_ = c.String(200, "foo")
+	}
+
+	require.NoError(t, r.Tree().Handle(http.MethodPost, "/", h))
+	req := httptest.NewRequest(http.MethodPost, "/", nil)
+	w := httptest.NewRecorder()
+	r.ServeHTTP(w, req)
+	require.Equal(t, http.StatusInternalServerError, w.Code)
+	assert.Equal(t, errMsg, w.Body.String())
+}
+
+func TestRecoveryMiddlewareWithBrokenPipe(t *testing.T) {
+	expectMsgs := map[syscall.Errno]string{
+		syscall.EPIPE:      "broken pipe",
+		syscall.ECONNRESET: "connection reset by peer",
+	}
+
+	for errno, expectMsg := range expectMsgs {
+		t.Run(expectMsg, func(t *testing.T) {
+			f := New(WithMiddleware(Recovery(func(c Context, err any) {
+				if !connIsBroken(err) {
+					http.Error(c.Writer(), http.StatusText(http.StatusInternalServerError), http.StatusInternalServerError)
+				}
+			})))
+			require.NoError(t, f.Handle(http.MethodGet, "/foo", func(c Context) {
+				e := &net.OpError{Err: &os.SyscallError{Err: errno}}
+				panic(e)
+			}))
+
+			req := httptest.NewRequest(http.MethodGet, "/foo", nil)
+			w := httptest.NewRecorder()
+			f.ServeHTTP(w, req)
+
+			assert.Equal(t, http.StatusOK, w.Code)
+		})
+	}
+}


### PR DESCRIPTION
Earlier this year, the [RFC: Route Overlapping](https://github.com/tigerwill90/fox/pull/9) was introduced to enhance the routing flexibility of the router by allowing overlapping of wildcard segments with static segments. The current rules, as outlined in the RFC, are as follows:

### Rules
1. Prioritize the more specific route:
    - If a catch-all or named route overlaps with a static route segment, the static segment should be prioritized.
2. Allow only one named or catch-all route to overlap with a static route segment.
3. Overlapping named parameters and catch-all parameters in the same segment is not allowed.
4. Each HTTP method has its own tree, so overlapping routes with different methods are allowed.

For example, the following route configurations are allowed:

````
/*{filepath}
/static
````
````
/content/{id}
/content/articles/{id}
/content/news/{id}
/content/events/{id}
````

### Proposition

While supporting overlapping named parameters, such as `/users/{id}/book` and `/users/{name}`, presents challenges, this new RFC aims to introduce the capability to overlap **catch-all and named parameter** segments (overlapping named parameters within the same segment remains prohibited at this stage).

As a result, the following route configurations would be allowed:
````
/*{filepath}
/{chain}/track
````
````
/users/uuid:{id}
/users/uuid:*{any}
````

### New Rules
- Static segments are always evaluated first.
- A named parameter can only overlap with a catch-all parameter or static segments.
- A catch-all parameter can only overlap with a named parameter or static segments.
- When a named parameter overlaps with a catch-all parameter, the named parameter is evaluated first.
- Each HTTP method has its own tree, so overlapping routes with different methods are allowed.

### Priority example

Pattern `/users/123/email`
| Route    | Matching order |
| -------- | ------- |
| /users/{id}/email   | 1    |
| /users/{id}/{action} | 2     |
| /users/*{any}      | 3     |


Pattern `/users/123/revoke`
| Route    | Matching order |
| -------- | ------- |
| /users/{id}/email   | no match    |
| /users/{id}/{action} | 1     |
| /users/*{any}      | 2     |

Pattern `/users/123/orders/5`
| Route    | Matching order |
| -------- | ------- |
| /users/{id}/email   | no match    |
| /users/{id}/{action} | no match     |
| /users/*{any}      | 1     |

### Performance comparaison
````
goos: linux
goarch: amd64
pkg: github.com/tigerwill90/fox
cpu: Intel(R) Core(TM) i9-9900K CPU @ 3.60GHz
                    │   old.txt    │               new.txt                │
                    │    sec/op    │    sec/op      vs base               │
StaticAll-16          11.01µ ±  2%    11.13µ ±  0%  +1.08% (p=0.019 n=10)
GithubParamsAll-16    86.16n ±  3%    92.61n ±  2%  +7.49% (p=0.000 n=10)
OverlappingRoute-16   98.58n ±  0%   103.15n ±  1%  +4.64% (p=0.000 n=10)
StaticParallel-16     10.04n ±  8%    10.48n ± 12%  +4.46% (p=0.015 n=10)
CatchAll-16           32.15n ±  1%    32.63n ±  2%       ~ (p=0.086 n=10)
CatchAllParallel-16   5.927n ± 20%    6.111n ± 14%       ~ (p=0.190 n=10)
MultiWriter-16        106.8n ±  1%    103.5n ±  2%  -3.14% (p=0.000 n=10)
geomean               346.1n          350.7n        +1.33%
````

The impact on performance is expected to be null for static route and minimal for wildcard route.