### PR TITLE
Add Safety Writer Option

### DIFF
--- a/context_test.go
+++ b/context_test.go
@@ -371,7 +371,7 @@ func TestContext_TeeWriter_flusher(t *testing.T) {
 			t.Parallel()
 			f := New()
 			dumper := bytes.NewBuffer(nil)
-			require.NoError(t, f.Handle(http.MethodGet, "/foo", WrapTestContextFlusher(tc.handler(dumper))))
+			require.NoError(t, f.Handle(http.MethodGet, "/foo", tc.handler(dumper)))
 
 			srv := httptest.NewServer(f)
 			defer srv.Close()

--- a/fox_test.go
+++ b/fox_test.go
@@ -484,18 +484,18 @@ func benchRouteParallel(b *testing.B, router http.Handler, rte route) {
 }
 
 func BenchmarkStaticAll(b *testing.B) {
-	r := New()
+	f := New()
 	for _, route := range staticRoutes {
-		require.NoError(b, r.Tree().Handle(route.method, route.path, emptyHandler))
+		require.NoError(b, f.Tree().Handle(route.method, route.path, emptyHandler))
 	}
 
-	benchRoutes(b, r, staticRoutes)
+	benchRoutes(b, f, staticRoutes)
 }
 
 func BenchmarkGithubParamsAll(b *testing.B) {
-	r := New()
+	f := New()
 	for _, route := range githubAPI {
-		require.NoError(b, r.Tree().Handle(route.method, route.path, emptyHandler))
+		require.NoError(b, f.Tree().Handle(route.method, route.path, emptyHandler))
 	}
 
 	req := httptest.NewRequest("GET", "/repos/sylvain/fox/hooks/1500", nil)
@@ -505,14 +505,14 @@ func BenchmarkGithubParamsAll(b *testing.B) {
 	b.ResetTimer()
 
 	for i := 0; i < b.N; i++ {
-		r.ServeHTTP(w, req)
+		f.ServeHTTP(w, req)
 	}
 }
 
 func BenchmarkOverlappingRoute(b *testing.B) {
-	r := New()
+	f := New()
 	for _, route := range overlappingRoutes {
-		require.NoError(b, r.Tree().Handle(route.method, route.path, emptyHandler))
+		require.NoError(b, f.Tree().Handle(route.method, route.path, emptyHandler))
 	}
 
 	req := httptest.NewRequest("GET", "/foo/abc/id:123/xy", nil)
@@ -522,21 +522,21 @@ func BenchmarkOverlappingRoute(b *testing.B) {
 	b.ResetTimer()
 
 	for i := 0; i < b.N; i++ {
-		r.ServeHTTP(w, req)
+		f.ServeHTTP(w, req)
 	}
 }
 
 func BenchmarkStaticParallel(b *testing.B) {
-	r := New()
+	f := New()
 	for _, route := range staticRoutes {
-		require.NoError(b, r.Tree().Handle(route.method, route.path, emptyHandler))
+		require.NoError(b, f.Tree().Handle(route.method, route.path, emptyHandler))
 	}
-	benchRouteParallel(b, r, route{"GET", "/progs/image_package4.out"})
+	benchRouteParallel(b, f, route{"GET", "/progs/image_package4.out"})
 }
 
 func BenchmarkCatchAll(b *testing.B) {
-	r := New()
-	require.NoError(b, r.Tree().Handle(http.MethodGet, "/something/*{args}", emptyHandler))
+	f := New()
+	require.NoError(b, f.Tree().Handle(http.MethodGet, "/something/*{args}", emptyHandler))
 	w := new(mockResponseWriter)
 	req := httptest.NewRequest("GET", "/something/awesome", nil)
 
@@ -544,13 +544,13 @@ func BenchmarkCatchAll(b *testing.B) {
 	b.ResetTimer()
 
 	for i := 0; i < b.N; i++ {
-		r.ServeHTTP(w, req)
+		f.ServeHTTP(w, req)
 	}
 }
 
 func BenchmarkCatchAllParallel(b *testing.B) {
-	r := New()
-	require.NoError(b, r.Tree().Handle(http.MethodGet, "/something/*{args}", emptyHandler))
+	f := New()
+	require.NoError(b, f.Tree().Handle(http.MethodGet, "/something/*{args}", emptyHandler))
 	w := new(mockResponseWriter)
 	req := httptest.NewRequest("GET", "/something/awesome", nil)
 
@@ -559,7 +559,7 @@ func BenchmarkCatchAllParallel(b *testing.B) {
 
 	b.RunParallel(func(pb *testing.PB) {
 		for pb.Next() {
-			r.ServeHTTP(w, req)
+			f.ServeHTTP(w, req)
 		}
 	})
 }

--- a/helpers.go
+++ b/helpers.go
@@ -20,26 +20,6 @@ func NewTestContextOnly(fox *Router, w http.ResponseWriter, r *http.Request) Con
 	return newTextContextOnly(fox, w, r)
 }
 
-// WrapTestContextFlusher method is a helper function provided for testing purposes. It wraps the provided HandlerFunc,
-// returning a new HandlerFunc that only exposes the http.Flusher interface of the ResponseWriter. This is useful for
-// testing implementations that rely on interface assertions with e.g. httptest.Recorder, since its only
-// supports the http.Flusher interface.
-// This API is EXPERIMENTAL and is likely to change in future release.
-func WrapTestContextFlusher(next HandlerFunc) HandlerFunc {
-	return func(c Context) {
-		c.SetWriter(onlyFlushWriter{c.Writer()})
-		next(c)
-	}
-}
-
-type onlyFlushWriter struct {
-	ResponseWriter
-}
-
-func (w onlyFlushWriter) Flush() {
-	w.ResponseWriter.(http.Flusher).Flush()
-}
-
 func newTextContextOnly(fox *Router, w http.ResponseWriter, r *http.Request) *context {
 	c := fox.Tree().allocateContext()
 	c.resetNil()

--- a/helpers_test.go
+++ b/helpers_test.go
@@ -15,46 +15,6 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func TestWrapFlushWriter(t *testing.T) {
-	buf := bytes.NewBuffer(nil)
-
-	f := New()
-	f.MustHandle(http.MethodGet, "/foo", WrapTestContextFlusher(func(c Context) {
-		_, ok := c.Writer().(http.Flusher)
-		require.True(t, ok)
-
-		c.TeeWriter(buf)
-		flusher, ok := c.Writer().(http.Flusher)
-		require.True(t, ok)
-
-		n, err := c.Writer().Write([]byte("foo"))
-		assert.NoError(t, err)
-		assert.Equal(t, 3, n)
-		flusher.Flush()
-
-		n, err = c.Writer().Write([]byte("bar"))
-		assert.NoError(t, err)
-		assert.Equal(t, 3, n)
-
-		assert.Equal(t, 6, c.Writer().Size())
-
-		_, ok = c.Writer().(http.Hijacker)
-		assert.False(t, ok)
-
-		_, ok = c.Writer().(io.ReaderFrom)
-		assert.False(t, ok)
-	}))
-
-	req := httptest.NewRequest(http.MethodGet, "/foo", nil)
-	w := httptest.NewRecorder()
-
-	f.ServeHTTP(w, req)
-
-	assert.Equal(t, "foobar", w.Body.String())
-	assert.Equal(t, "foobar", buf.String())
-	assert.True(t, w.Flushed)
-}
-
 func TestNewTestContext(t *testing.T) {
 	req := httptest.NewRequest(http.MethodGet, "/foo", nil)
 	w := httptest.NewRecorder()


### PR DESCRIPTION
### Description
This PR introduces a new "Response Writer Safety" feature to address potential panics that can arise when the router or its middlewares make assumptions about the capabilities of custom `http.ResponseWriter` implementations.

### Background
Certain middlewares or handlers, like `http.TimeoutHandler`, wrap the original `http.ResponseWriter` and might return a new writer that omits certain interfaces, such as `http.Flusher`. Routers like `Fox`, `Gin`, and `Echo` traditionally assume these interfaces to be present. The absence of these interfaces can lead to undefined behavior or even cause a panic under specific circumstances.

For example, the following implementation with `httputil.ReverseProxy` will result in a panic for `Fox`, `Echo` and `Gin`.

````go
func main() {
	url, _ := url.Parse("https://tf1pub.drawapi.com/ssai/multi-slots/16-avec-des-trous")
	proxy := httputil.NewSingleHostReverseProxy(url)

	proxy.Director = func(req *http.Request) {
		req.URL.Scheme = url.Scheme
		req.URL.Host = url.Host
		req.URL.Path = url.Path
		req.Host = url.Host
	}

	f := fox.New()
	f.MustHandle(http.MethodGet, "/", FoxProxyRequestHandler(proxy))

	g := gin.Default()
	g.Handle(http.MethodGet, "/", GinProxyRequestHandler(proxy))

	e := echo.New()
	e.GET("/", EchoProxyRequestHandler(proxy))

	log.Fatalln(http.ListenAndServe(":8080", http.TimeoutHandler(f, 1*time.Second, http.StatusText(http.StatusServiceUnavailable))))
}

func FoxProxyRequestHandler(proxy *httputil.ReverseProxy) fox.HandlerFunc {
	return func(c fox.Context) {
		proxy.ServeHTTP(c.Writer(), c.Request())
	}
}

func GinProxyRequestHandler(proxy *httputil.ReverseProxy) gin.HandlerFunc {
	return func(c *gin.Context) {
		proxy.ServeHTTP(c.Writer, c.Request)
	}
}

func EchoProxyRequestHandler(proxy *httputil.ReverseProxy) echo.HandlerFunc {
	return func(c echo.Context) error {
		proxy.ServeHTTP(c.Response(), c.Request())
		return nil
	}
}
````

When `httputil.ReverseProxy` checks if the provided writer implements `http.Flusher` and the check succeeds (because it use the writer from, say, `Echo` or `Gin`), it will attempt to use it (based on the number of bytes already written). But since the real writer behind the scenes (from `http.TimeoutHandler`) doesn't actually support this, a panic occurs.

### Introduction of the `WithWriterSafety` Option:

This PR introduces an option called `WithWriterSafety` to ensure more predictable behavior when working with different `http.ResponseWriter` implementations.

**Behavior**

- Safe Mode (`WithWriterSafety` Enabled):
The router derives the protocol from the request's `ProtoMajor` and conducts explicit type assertions on the provided `http.ResponseWriter`. This ensures compatibility across various writer implementations and safeguards against unpredictable outcomes.

- Optimistic Mode (Default Behavior without `WithWriterSafety`):
The router operates under an optimistic assumption that the provided `http.ResponseWriter` fully supports the necessary interfaces for the request's protocol. Specifically, for HTTP/1.x requests, the writer should implement `http.Flusher`, `http.Hijacker`, and `io.ReaderFrom`. For HTTP/2 requests, the writer should support `http.Flusher` and `http.Pusher`.

**Example**
````go
f := fox.New(fox.WithWriterSafety(true))
f.MustHandle(http.MethodGet, "/", FoxProxyRequestHandler(proxy))
log.Fatalln(http.ListenAndServe(":8080", http.TimeoutHandler(f, 1*time.Second, http.StatusText(http.StatusServiceUnavailable))))
````

**Peformance**
In Safe Mode, benchmarks show a performance drop of ~30% due to multiple interface assertions ensuring safety. However, Fox remains more performant than both `Gin` and `Echo` in most scenarios.