### PR TITLE
Ignore trailing slash

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,6 +34,9 @@ priority rules, ensuring that there are no unintended matches and maintaining hi
 **Redirect trailing slashes:** Inspired from [httprouter](https://github.com/julienschmidt/httprouter), the router automatically 
 redirects the client, at no extra cost, if another route match with or without a trailing slash.
 
+**Ignore trailing slashes:** In contrast to redirecting, this option allows the router to handle requests regardless of an extra 
+or missing trailing slash, at no extra cost.
+
 **Automatic OPTIONS replies:** Inspired from [httprouter](https://github.com/julienschmidt/httprouter), the router has built-in native
 support for [OPTIONS requests](https://developer.mozilla.org/en-US/docs/Web/HTTP/Methods/OPTIONS).
 

--- a/README.md
+++ b/README.md
@@ -623,6 +623,7 @@ BenchmarkPat_GithubAll               424           2899405 ns/op         1843501
 - [x] [Update route syntax](https://github.com/tigerwill90/fox/pull/10#issue-1643728309) @v0.6.0
 - [x] [Route overlapping](https://github.com/tigerwill90/fox/pull/9#issue-1642887919) @v0.7.0
 - [x] [Route overlapping (catch-all and params)](https://github.com/tigerwill90/fox/pull/24#issue-1784686061) @v0.10.0
+- [x] [Ignore trailing slash](https://github.com/tigerwill90/fox/pull/32) @v0.14.0
 - [ ] Improving performance and polishing
 
 ## Contributions

--- a/context.go
+++ b/context.go
@@ -78,11 +78,12 @@ type Context interface {
 	CloneWith(w ResponseWriter, r *http.Request) ContextCloser
 	// Tree is a local copy of the Tree in use to serve the request.
 	Tree() *Tree
-	// Fox returns the Router in use to serve the request.
+	// Fox returns the Router instance.
 	Fox() *Router
-	// Reset resets the Context to its initial state, attaching the provided Router,
-	// http.ResponseWriter, and *http.Request.
-	Reset(fox *Router, w http.ResponseWriter, r *http.Request)
+	// Reset resets the Context to its initial state, attaching the provided Router, http.ResponseWriter, and *http.Request.
+	// Caution: You should always pass the original http.ResponseWriter to this method, not the ResponseWriter itself, to
+	// avoid wrapping the ResponseWriter within itself. Use wisely!
+	Reset(w http.ResponseWriter, r *http.Request)
 }
 
 // context holds request-related information and allows interaction with the ResponseWriter.
@@ -102,13 +103,13 @@ type context struct {
 }
 
 // Reset resets the Context to its initial state, attaching the provided Router, http.ResponseWriter, and *http.Request.
-// Caution: You should pass the original http.ResponseWriter to this method, not the ResponseWriter itself, to avoid
-// wrapping the ResponseWriter within itself.
-func (c *context) Reset(fox *Router, w http.ResponseWriter, r *http.Request) {
+// Caution: You should always pass the original http.ResponseWriter to this method, not the ResponseWriter itself, to
+// avoid wrapping the ResponseWriter within itself. Use wisely!
+func (c *context) Reset(w http.ResponseWriter, r *http.Request) {
 	c.rec.reset(w)
 	c.req = r
 	c.w = &c.rec
-	c.fox = fox
+	c.fox = c.tree.fox
 	c.path = ""
 	c.cachedQuery = nil
 	*c.params = (*c.params)[:0]
@@ -233,7 +234,7 @@ func (c *context) Tree() *Tree {
 	return c.tree
 }
 
-// Fox returns the Router in use to serve the request.
+// Fox returns the Router instance.
 func (c *context) Fox() *Router {
 	return c.fox
 }

--- a/fox.go
+++ b/fox.go
@@ -85,6 +85,34 @@ func New(opts ...Option) *Router {
 	return r
 }
 
+// MethodNotAllowedEnabled returns whether the router is configured to handle
+// requests with methods that are not allowed.
+// This api is EXPERIMENTAL and is likely to change in future release.
+func (fox *Router) MethodNotAllowedEnabled() bool {
+	return fox.handleMethodNotAllowed
+}
+
+// AutoOptionsEnabled returns whether the router is configured to automatically
+// respond to OPTIONS requests.
+// This api is EXPERIMENTAL and is likely to change in future release.
+func (fox *Router) AutoOptionsEnabled() bool {
+	return fox.handleOptions
+}
+
+// RedirectTrailingSlashEnabled returns whether the router is configured to automatically
+// redirect requests that include or omit a trailing slash.
+// This api is EXPERIMENTAL and is likely to change in future release.
+func (fox *Router) RedirectTrailingSlashEnabled() bool {
+	return fox.redirectTrailingSlash
+}
+
+// IgnoreTrailingSlashEnabled returns whether the router is configured to ignore
+// trailing slashes in requests when matching routes.
+// This api is EXPERIMENTAL and is likely to change in future release.
+func (fox *Router) IgnoreTrailingSlashEnabled() bool {
+	return fox.ignoreTrailingSlash
+}
+
 // NewTree returns a fresh routing Tree that inherits all registered router options. It's safe to create multiple Tree
 // concurrently. However, a Tree itself is not thread-safe and all its APIs that perform write operations should be run
 // serially. Note that a Tree give direct access to the underlying sync.Mutex.

--- a/fox.go
+++ b/fox.go
@@ -195,11 +195,10 @@ func (fox *Router) Remove(method, path string) error {
 	return t.Remove(method, path)
 }
 
-// Lookup performs a manual route lookup for a given http.Request, returning the matched HandlerFunc along with a ContextCloser,
-// and a boolean indicating if a trailing slash action (e.g. redirect) is recommended (tsr). The ContextCloser should always be closed if non-nil.
-// This method is primarily intended for integrating the fox router into custom routing solutions. It requires the use of the
-// original http.ResponseWriter, typically obtained from ServeHTTP. This function is safe for concurrent use by multiple goroutine
-// and while mutation on Tree are ongoing. If there is a direct match or a tsr is possible, Lookup always return a HandlerFunc and a ContextCloser.
+// Lookup is a helper that calls Tree.Lookup. For more details, refer to Tree.Lookup.
+// It performs a manual route lookup for a given http.Request, returning the matched HandlerFunc along with a ContextCloser,
+// and a boolean indicating if a trailing slash action (e.g. redirect) is recommended (tsr). The ContextCloser should always
+// be closed if non-nil.
 // This API is EXPERIMENTAL and is likely to change in future release.
 func (fox *Router) Lookup(w http.ResponseWriter, r *http.Request) (handler HandlerFunc, cc ContextCloser, tsr bool) {
 	tree := fox.tree.Load()

--- a/fox.go
+++ b/fox.go
@@ -92,7 +92,7 @@ func New(opts ...Option) *Router {
 func (fox *Router) NewTree() *Tree {
 	tree := new(Tree)
 	tree.mws = fox.mws
-	tree.ignoreTrailingSlash = fox.ignoreTrailingSlash
+	tree.ingorets = fox.ignoreTrailingSlash || fox.redirectTrailingSlash
 
 	// Pre instantiate nodes for common http verb
 	nds := make([]*node, len(commonVerbs))

--- a/fox.go
+++ b/fox.go
@@ -611,11 +611,8 @@ func applyMiddleware(scope MiddlewareScope, mws []middleware, h HandlerFunc) Han
 }
 
 // localRedirect redirect the client to the new path, but it does not convert relative paths to absolute paths
-// like Redirect does.
-// If the Content-Type header has not been set, localRedirect sets it
-// to "text/html; charset=utf-8" and writes a small HTML body.
-// Setting the Content-Type header to any value, including nil,
-// disables that behavior.
+// like Redirect does. If the Content-Type header has not been set, localRedirect sets it to "text/html; charset=utf-8"
+// and writes a small HTML body. Setting the Content-Type header to any value, including nil, disables that behavior.
 func localRedirect(w http.ResponseWriter, r *http.Request, path string, code int) {
 	if q := r.URL.RawQuery; q != "" {
 		path += "?" + q

--- a/fox_test.go
+++ b/fox_test.go
@@ -1726,6 +1726,7 @@ func TestRouterWithIgnoreTrailingSlash(t *testing.T) {
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
 			r := New(WithIgnoreTrailingSlash(true))
+			require.True(t, r.IgnoreTrailingSlashEnabled())
 			for _, path := range tc.paths {
 				require.NoError(t, r.Tree().Handle(tc.method, path, func(c Context) {
 					_ = c.String(http.StatusOK, c.Path())
@@ -1871,6 +1872,7 @@ func TestRedirectTrailingSlash(t *testing.T) {
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
 			r := New(WithRedirectTrailingSlash(true))
+			require.True(t, r.RedirectTrailingSlashEnabled())
 			for _, path := range tc.paths {
 				require.NoError(t, r.Tree().Handle(tc.method, path, emptyHandler))
 			}
@@ -1997,6 +1999,7 @@ func TestRouterWithAllowedMethod(t *testing.T) {
 		},
 	}
 
+	require.True(t, r.MethodNotAllowedEnabled())
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
 			for _, method := range tc.methods {
@@ -2168,6 +2171,7 @@ func TestRouterWithAutomaticOptions(t *testing.T) {
 		},
 	}
 
+	require.True(t, f.AutoOptionsEnabled())
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
 			for _, method := range tc.methods {
@@ -2418,6 +2422,7 @@ func TestTree_Has(t *testing.T) {
 		"/foo/bar",
 		"/welcome/{name}",
 		"/users/uid_{id}",
+		"/john/doe/",
 	}
 
 	r := New()
@@ -2436,8 +2441,17 @@ func TestTree_Has(t *testing.T) {
 			want: true,
 		},
 		{
-			name: "no match static route (no tsr)",
+			name: "strict match static route",
+			path: "/john/doe/",
+			want: true,
+		},
+		{
+			name: "no match static route (tsr)",
 			path: "/foo/bar/",
+		},
+		{
+			name: "no match static route (tsr)",
+			path: "/john/doe",
 		},
 		{
 			name: "strict match route params",
@@ -2455,79 +2469,6 @@ func TestTree_Has(t *testing.T) {
 		},
 		{
 			name: "no match mid route params",
-			path: "/users/uid_123",
-		},
-	}
-
-	tree := r.Tree()
-	for _, tc := range cases {
-		t.Run(tc.name, func(t *testing.T) {
-			assert.Equal(t, tc.want, tree.Has(http.MethodGet, tc.path))
-		})
-	}
-}
-
-func TestTree_HasWithIgnoreTrailingSlashEnable(t *testing.T) {
-	routes := []string{
-		"/foo/bar",
-		"/welcome/{name}/",
-		"/users/uid_{id}",
-	}
-
-	r := New(WithIgnoreTrailingSlash(true))
-	for _, rte := range routes {
-		require.NoError(t, r.Handle(http.MethodGet, rte, emptyHandler))
-	}
-
-	cases := []struct {
-		name string
-		path string
-		want bool
-	}{
-		{
-			name: "strict match static route",
-			path: "/foo/bar",
-			want: true,
-		},
-		{
-			name: "no match static route with tsr",
-			path: "/foo/bar/",
-			want: true,
-		},
-		{
-			name: "strict match route params",
-			path: "/welcome/{name}/",
-			want: true,
-		},
-		{
-			name: "strict match route params with tsr",
-			path: "/welcome/{name}",
-			want: true,
-		},
-		{
-			name: "no match route params with ts",
-			path: "/welcome/fox",
-		},
-		{
-			name: "no match route params without ts",
-			path: "/welcome/fox/",
-		},
-		{
-			name: "strict match mid route params",
-			path: "/users/uid_{id}",
-			want: true,
-		},
-		{
-			name: "strict match mid route params with tsr",
-			path: "/users/uid_{id}/",
-			want: true,
-		},
-		{
-			name: "no match mid route params without ts",
-			path: "/users/uid_123",
-		},
-		{
-			name: "no match mid route params with ts",
 			path: "/users/uid_123",
 		},
 	}

--- a/go.mod
+++ b/go.mod
@@ -4,7 +4,7 @@ go 1.19
 
 require (
 	github.com/google/gofuzz v1.2.0
-	github.com/stretchr/testify v1.8.4
+	github.com/stretchr/testify v1.9.0
 )
 
 require (

--- a/go.sum
+++ b/go.sum
@@ -17,8 +17,8 @@ github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZN
 github.com/rogpeppe/go-internal v1.6.1/go.mod h1:xXDCJY+GAPziupqXw64V24skbSoqbTEfhy4qGm1nDQc=
 github.com/rogpeppe/go-internal v1.8.0 h1:FCbCCtXNOY3UtUuHUYaghJg4y7Fd14rXifAYUAtL9R8=
 github.com/rogpeppe/go-internal v1.8.0/go.mod h1:WmiCO8CzOY8rg0OYDC4/i/2WRWAB6poM+XZ2dLUbcbE=
-github.com/stretchr/testify v1.8.4 h1:CcVxjf3Q8PM0mHUKJCdn+eZZtm5yQwehR5yeSVQQcUk=
-github.com/stretchr/testify v1.8.4/go.mod h1:sz/lmYIOXD/1dqDmKjjqLyZ2RngseejIcXlSw2iwfAo=
+github.com/stretchr/testify v1.9.0 h1:HtqpIVDClZ4nwg75+f6Lvsy/wHu+3BoSGCbBAcpTsTg=
+github.com/stretchr/testify v1.9.0/go.mod h1:r2ic/lqez/lEtzL7wO/rwa5dbSLXVDPFyf8C91i36aY=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
 gopkg.in/check.v1 v1.0.0-20180628173108-788fd7840127/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
 gopkg.in/check.v1 v1.0.0-20201130134442-10cb98267c6c h1:Hei/4ADfdWqJk1ZMxUNpqntNwaWcugrBjAiHlqqRiVk=

--- a/node.go
+++ b/node.go
@@ -214,7 +214,7 @@ func (n *skippedNodes) pop() skippedNode {
 }
 
 type skippedNode struct {
-	node      *node
+	parent    *node
 	pathIndex int
 	paramCnt  uint32
 	seen      bool

--- a/options.go
+++ b/options.go
@@ -114,7 +114,7 @@ func WithAutoOptions(enable bool) Option {
 // another handler is found with/without an additional trailing slash. E.g. /foo/bar/ request does not match
 // but /foo/bar would match. The client is redirected with a http status code 301 for GET requests and 308 for
 // all other methods. Note that this option is mutually exclusive with WithIgnoreTrailingSlash, and if both are
-// enabled, WithRedirectTrailingSlash takes precedence.
+// enabled, WithIgnoreTrailingSlash takes precedence.
 func WithRedirectTrailingSlash(enable bool) Option {
 	return optionFunc(func(r *Router) {
 		r.redirectTrailingSlash = enable
@@ -124,7 +124,7 @@ func WithRedirectTrailingSlash(enable bool) Option {
 // WithIgnoreTrailingSlash allows the router to match routes regardless of whether a trailing slash is present or not.
 // E.g. /foo/bar/ and /foo/bar would both match the same handler. This option prevents the router from issuing
 // a redirect and instead matches the request directly. Note that this option is mutually exclusive with
-// WithRedirectTrailingSlash, and if both are enabled, WithRedirectTrailingSlash takes precedence.
+// WithRedirectTrailingSlash, and if both are enabled, WithIgnoreTrailingSlash takes precedence.
 // This api is EXPERIMENTAL and is likely to change in future release.
 func WithIgnoreTrailingSlash(enable bool) Option {
 	return optionFunc(func(r *Router) {

--- a/options.go
+++ b/options.go
@@ -113,10 +113,22 @@ func WithAutoOptions(enable bool) Option {
 // WithRedirectTrailingSlash enable automatic redirection fallback when the current request does not match but
 // another handler is found with/without an additional trailing slash. E.g. /foo/bar/ request does not match
 // but /foo/bar would match. The client is redirected with a http status code 301 for GET requests and 308 for
-// all other methods.
+// all other methods. Note that this option is mutually exclusive with WithIgnoreTrailingSlash, and if both are
+// enabled, WithRedirectTrailingSlash takes precedence.
 func WithRedirectTrailingSlash(enable bool) Option {
 	return optionFunc(func(r *Router) {
 		r.redirectTrailingSlash = enable
+	})
+}
+
+// WithIgnoreTrailingSlash allows the router to match routes regardless of whether a trailing slash is present or not.
+// E.g. /foo/bar/ and /foo/bar would both match the same handler. This option prevents the router from issuing
+// a redirect and instead matches the request directly. Note that this option is mutually exclusive with
+// WithRedirectTrailingSlash, and if both are enabled, WithRedirectTrailingSlash takes precedence.
+// This api is EXPERIMENTAL and is likely to change in future release.
+func WithIgnoreTrailingSlash(enable bool) Option {
+	return optionFunc(func(r *Router) {
+		r.ignoreTrailingSlash = enable
 	})
 }
 

--- a/tree.go
+++ b/tree.go
@@ -114,10 +114,10 @@ func (t *Tree) Has(method, path string) bool {
 	return false
 }
 
-// Match perform a lookup on the tree for the given method and path and return the matching registered route if any. When
+// Match perform a reverse lookup on the tree for the given method and path and return the matching registered route if any. When
 // WithIgnoreTrailingSlash or WithRedirectTrailingSlash are enabled, Match will match a registered route regardless of an
 // extra or missing trailing slash. This function is safe for concurrent use by multiple goroutine and while mutation on
-// Tree are ongoing.
+// Tree are ongoing. See also Tree.Lookup as an alternative.
 // This API is EXPERIMENTAL and is likely to change in future release.
 func (t *Tree) Match(method, path string) string {
 	nds := *t.nodes.Load()
@@ -138,7 +138,7 @@ func (t *Tree) Match(method, path string) string {
 
 // Methods returns a sorted list of HTTP methods associated with a given path in the routing tree. If the path is "*",
 // it returns all HTTP methods that have at least one route registered in the tree. For a specific path, it returns the
-// methods that can route requests to that path.  When WithIgnoreTrailingSlash or WithRedirectTrailingSlash are enabled,
+// methods that can route requests to that path. When WithIgnoreTrailingSlash or WithRedirectTrailingSlash are enabled,
 // Methods will match a registered route regardless of an extra or missing trailing slash. This function is safe for
 // concurrent use by multiple goroutine and while mutation on Tree are ongoing.
 // This API is EXPERIMENTAL and is likely to change in future release.
@@ -174,11 +174,13 @@ func (t *Tree) Methods(path string) []string {
 	return methods
 }
 
-// Lookup performs a manual route lookup for a given http.Request, returning the matched HandlerFunc along with a ContextCloser,
-// and a boolean indicating if a trailing slash action (e.g. redirect) is recommended (tsr). The ContextCloser should always be closed if non-nil.
-// This method is primarily intended for integrating the fox router into custom routing solutions. It requires the use of the
-// original http.ResponseWriter, typically obtained from ServeHTTP. This function is safe for concurrent use by multiple goroutine
-// and while mutation on Tree are ongoing. If there is a direct match or a tsr is possible, Lookup always return a HandlerFunc and a ContextCloser.
+// Lookup performs a manual route lookup for a given http.Request, returning the matched HandlerFunc along with a
+// ContextCloser, and a boolean indicating if the handler was matched by adding or removing a trailing slash
+// (trailing slash action is recommended). The ContextCloser should always be closed if non-nil. This method is primarily
+// intended for integrating the fox router into custom routing solutions or middleware. It requires the use of the original
+// http.ResponseWriter, typically obtained from ServeHTTP. This function is safe for concurrent use by multiple goroutine
+// and while mutation on Tree are ongoing. If there is a direct match or a tsr is possible, Lookup always return a
+// HandlerFunc and a ContextCloser.
 // This API is EXPERIMENTAL and is likely to change in future release.
 func (t *Tree) Lookup(w http.ResponseWriter, r *http.Request) (handler HandlerFunc, cc ContextCloser, tsr bool) {
 	nds := *t.nodes.Load()

--- a/tree.go
+++ b/tree.go
@@ -606,10 +606,12 @@ Walk:
 			// Key end mid-edge
 			if !tsr {
 				if strings.HasSuffix(path, "/") {
+					// TODO need last
 					// Tsr recommendation: remove the extra trailing slash (got an exact match)
 					remainingPrefix := current.key[:charsMatchedInNodeFound]
 					tsr = len(remainingPrefix) == 1 && remainingPrefix[0] == slashDelim
 				} else {
+					// TODO current
 					// Tsr recommendation: add an extra trailing slash (got an exact match)
 					remainingSuffix := current.key[charsMatchedInNodeFound:]
 					tsr = len(remainingSuffix) == 1 && remainingSuffix[0] == slashDelim
@@ -637,6 +639,7 @@ Walk:
 
 		// Tsr recommendation: remove the extra trailing slash (got an exact match)
 		if !tsr {
+			// TODO current
 			remainingKeySuffix := path[charsMatched:]
 			tsr = len(remainingKeySuffix) == 1 && remainingKeySuffix[0] == slashDelim
 		}

--- a/tree.go
+++ b/tree.go
@@ -112,7 +112,7 @@ func (t *Tree) Has(method, path string) bool {
 		return false
 	}
 	if n.path == path {
-		return !tsr
+		return true
 	}
 	if tsr && t.ignoreTrailingSlash {
 		return n.path == fixTrailingSlash(path)

--- a/tree.go
+++ b/tree.go
@@ -144,7 +144,8 @@ func (t *Tree) Match(method, path string) string {
 
 // Methods returns a sorted list of HTTP methods associated with a given path in the routing tree. If the path is "*",
 // it returns all HTTP methods that have at least one route registered in the tree. For a specific path, it returns the methods
-// that can route requests to that path.
+// that can route requests to that path.  When WithIgnoreTrailingSlash is enabled, Methods will match a registered route
+// regardless of an extra or missing trailing slash.
 // This function is safe for concurrent use by multiple goroutine and while mutation on Tree are ongoing.
 // This API is EXPERIMENTAL and is likely to change in future release.
 func (t *Tree) Methods(path string) []string {

--- a/tree.go
+++ b/tree.go
@@ -93,9 +93,8 @@ func (t *Tree) Remove(method, path string) error {
 	return nil
 }
 
-// Has allows to check if the given method and path exactly match a registered route. When WithIgnoreTrailingSlash
-// or WithRedirectTrailingSlash are enabled, Has will match a registered route regardless of an extra or missing trailing
-// slash. This function is safe for concurrent use by multiple goroutine and while mutation on Tree are ongoing.
+// Has allows to check if the given method and path exactly match a registered route. This function is safe for concurrent
+// use by multiple goroutine and while mutation on Tree are ongoing.
 // This API is EXPERIMENTAL and is likely to change in future release.
 func (t *Tree) Has(method, path string) bool {
 	nds := *t.nodes.Load()
@@ -108,16 +107,9 @@ func (t *Tree) Has(method, path string) bool {
 	c.resetNil()
 	n, tsr := t.lookup(nds[index], path, c.params, c.skipNds, true)
 	c.Close()
-	if n == nil {
-		return false
+	if n != nil && !tsr {
+		return n.path == path
 	}
-	if n.path == path {
-		return true
-	}
-	if tsr && t.ingorets {
-		return n.path == fixTrailingSlash(path)
-	}
-
 	return false
 }
 


### PR DESCRIPTION
## Summary

This pull request introduces a new feature to Fox: the ability to ignore trailing slashes in URL paths. While redirecting or ignoring trailing slashes for an API endpoint is not typically advised, it may be desirable for websites. Both methods have their pros and cons, and most routers, including Fox, choose to redirect the client with a 301 status code for trailing slashes.

For example, `https://apple.com/iphone` redirects you to `https://apple.com/iphone/` with a 301 Moved Permanently, while `https://github.com/tigerwill90/fox/` and `https://github.com/tigerwill90/fox` both match the same resource without any redirection.

This new feature allows the router to handle requests regardless of the presence or absence of a trailing slash.

## Details

- In contrast to the existing redirect trailing slashes feature, which redirects the client if a route with or without a trailing slash matches, this new feature allows the router to handle the request directly.
- This feature operates at no extra cost. There is no need to perform an additional lookup to find if a path would match with or without the trailing slash.
- The `WithIgnoreTrailingSlash` and `WithRedirectTrailingSlash` options are mutually exclusive. If both are enabled, `WithIgnoreTrailingSlash` takes precedence.

## Example

In this example, all the following requests match a handler:
- `/articles`
- `/articles/`
- `/articles/12`
- `/articles/51/`

```go
f := fox.New(fox.WithIgnoreTrailingSlash(true))

f.MustHandle(http.MethodGet, "/articles", func(c fox.Context) {
	_ = c.String(http.StatusOK, "Here is a list of articles\n")
})
f.MustHandle(http.MethodGet, "/articles/{id}", func(c fox.Context) {
	_ = c.String(http.StatusOK, "Here is article %s\n", c.Param("id"))
})
```

## Consistent Behavior with Tree API

The Tree API allows the user to access lower-level functions like `Match`, `Has`, `Methods`, and `Lookup`, which may be useful for managing routes at runtime. These methods will also ignore the trailing slash if the option is enabled.

## Bug Fix

An edge case has been fixed for both the redirect trailing slash and the new ignore trailing slash feature. In some scenarios, the router would miss a possible redirect recommendation if the path exactly matched an intermediary node (without a handler).

```
/foo [leaf=/foo]
     /
         b/ [leaf=/foo/b/]
         x/ [leaf=/foo/x/]
```

In this circumstance, `/foo/` can be redirected to `/foo` but was previously missed by the router. Now, the lookup function correctly handles this edge case.

## Benchmark Differential

Expect none or negligible impact on performance.

```text
goos: linux
goarch: amd64
pkg: github.com/tigerwill90/fox
cpu: Intel(R) Core(TM) i9-9900K CPU @ 3.60GHz
                    │    old.txt    │               new.txt               │
                    │    sec/op     │    sec/op     vs base               │
StaticAll-16           11.68µ ±  1%   11.85µ ±  2%       ~ (p=0.089 n=10)
GithubParamsAll-16     82.21n ±  2%   83.72n ±  1%  +1.84% (p=0.000 n=10)
OverlappingRoute-16    99.98n ±  1%   96.13n ±  1%  -3.85% (p=0.000 n=10)
StaticParallel-16     10.105n ±  1%   9.345n ±  2%  -7.53% (p=0.001 n=10)
CatchAll-16            31.71n ±  1%   31.87n ±  2%       ~ (p=0.128 n=10)
CatchAllParallel-16    5.742n ± 13%   5.712n ± 24%       ~ (p=0.739 n=10)
CloneWith-16           65.60n ±  1%   67.57n ±  2%  +3.00% (p=0.000 n=10)
geomean                73.50n         72.92n        -0.79%
```

## Path to v1.0.0
We are gradually moving towards the v1.0.0 release. While some API inconsistencies remain, along with necessary code cleanup and documentation updates, we anticipate reaching v1.0.0 during the summer.