### PR TITLE
Fix : invalid params when using ignore trailing slash

### DIFF
--- a/fox.go
+++ b/fox.go
@@ -341,7 +341,7 @@ func (fox *Router) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 		goto NoMethodFallback
 	}
 
-	n, tsr = tree.lookup(nds[index], target, c.params, c.skipNds, false)
+	n, tsr = tree.lookup(nds[index], target, c, false)
 	if !tsr && n != nil {
 		c.path = n.path
 		n.handler(c)
@@ -390,7 +390,7 @@ NoMethodFallback:
 			}
 		} else {
 			for i := 0; i < len(nds); i++ {
-				if n, tsr := tree.lookup(nds[i], target, c.params, c.skipNds, true); n != nil && (!tsr || fox.ignoreTrailingSlash) {
+				if n, tsr := tree.lookup(nds[i], target, c, true); n != nil && (!tsr || fox.ignoreTrailingSlash) {
 					if sb.Len() > 0 {
 						sb.WriteString(", ")
 					} else {
@@ -413,7 +413,7 @@ NoMethodFallback:
 		var sb strings.Builder
 		for i := 0; i < len(nds); i++ {
 			if nds[i].key != r.Method {
-				if n, tsr := tree.lookup(nds[i], target, c.params, c.skipNds, true); n != nil && (!tsr || fox.ignoreTrailingSlash) {
+				if n, tsr := tree.lookup(nds[i], target, c, true); n != nil && (!tsr || fox.ignoreTrailingSlash) {
 					if sb.Len() > 0 {
 						sb.WriteString(", ")
 					}

--- a/fox_test.go
+++ b/fox_test.go
@@ -715,7 +715,7 @@ func TestRouteWithParams(t *testing.T) {
 	nds := *tree.nodes.Load()
 	for _, rte := range routes {
 		c := newTestContextTree(tree)
-		n, tsr := tree.lookup(nds[0], rte, c.params, c.skipNds, false)
+		n, tsr := tree.lookup(nds[0], rte, c, false)
 		require.NotNil(t, n)
 		assert.False(t, tsr)
 		assert.Equal(t, rte, n.path)
@@ -754,7 +754,7 @@ func TestRouteParamEmptySegment(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			nds := *tree.nodes.Load()
 			c := newTestContextTree(tree)
-			n, tsr := tree.lookup(nds[0], tc.path, c.params, c.skipNds, false)
+			n, tsr := tree.lookup(nds[0], tc.path, c, false)
 			assert.Nil(t, n)
 			assert.Empty(t, c.Params())
 			assert.False(t, tsr)
@@ -1161,7 +1161,7 @@ func TestOverlappingRoute(t *testing.T) {
 			nds := *tree.nodes.Load()
 
 			c := newTestContextTree(tree)
-			n, tsr := tree.lookup(nds[0], tc.path, c.params, c.skipNds, false)
+			n, tsr := tree.lookup(nds[0], tc.path, c, false)
 			require.NotNil(t, n)
 			require.NotNil(t, n.handler)
 			assert.False(t, tsr)
@@ -1174,7 +1174,7 @@ func TestOverlappingRoute(t *testing.T) {
 
 			// Test with lazy
 			c = newTestContextTree(tree)
-			n, tsr = tree.lookup(nds[0], tc.path, c.params, c.skipNds, true)
+			n, tsr = tree.lookup(nds[0], tc.path, c, true)
 			require.NotNil(t, n)
 			require.NotNil(t, n.handler)
 			assert.False(t, tsr)
@@ -1614,7 +1614,7 @@ func TestTree_LookupTsr(t *testing.T) {
 			}
 			nds := *tree.nodes.Load()
 			c := newTestContextTree(tree)
-			n, got := tree.lookup(nds[0], tc.key, c.params, c.skipNds, true)
+			n, got := tree.lookup(nds[0], tc.key, c, true)
 			assert.Equal(t, tc.want, got)
 			if tc.want {
 				require.NotNil(t, n)
@@ -2644,7 +2644,7 @@ func TestFuzzInsertLookupParam(t *testing.T) {
 			nds := *tree.nodes.Load()
 
 			c := newTestContextTree(tree)
-			n, tsr := tree.lookup(nds[0], fmt.Sprintf(reqFormat, s1, "xxxx", s2, "xxxx", "xxxx"), c.params, c.skipNds, false)
+			n, tsr := tree.lookup(nds[0], fmt.Sprintf(reqFormat, s1, "xxxx", s2, "xxxx", "xxxx"), c, false)
 			require.NotNil(t, n)
 			assert.False(t, tsr)
 			assert.Equal(t, fmt.Sprintf(routeFormat, s1, e1, s2, e2, e3), n.path)
@@ -2704,7 +2704,7 @@ func TestFuzzInsertLookupUpdateAndDelete(t *testing.T) {
 	for rte := range routes {
 		nds := *tree.nodes.Load()
 		c := newTestContextTree(tree)
-		n, tsr := tree.lookup(nds[0], "/"+rte, c.params, c.skipNds, true)
+		n, tsr := tree.lookup(nds[0], "/"+rte, c, true)
 		require.NotNilf(t, n, "route /%s", rte)
 		require.Falsef(t, tsr, "tsr: %t", tsr)
 		require.Truef(t, n.isLeaf(), "route /%s", rte)

--- a/fox_test.go
+++ b/fox_test.go
@@ -13,6 +13,7 @@ import (
 	"net/http/httptest"
 	"reflect"
 	"regexp"
+	"slices"
 	"strings"
 	"sync"
 	"sync/atomic"
@@ -496,7 +497,7 @@ func BenchmarkGithubParamsAll(b *testing.B) {
 		require.NoError(b, r.Tree().Handle(route.method, route.path, emptyHandler))
 	}
 
-	req := httptest.NewRequest("GET", "/repos/sylvain/fox/hooks/1500", nil)
+	req := httptest.NewRequest(http.MethodGet, "/repos/sylvain/fox/hooks/1500", nil)
 	w := new(mockResponseWriter)
 
 	b.ReportAllocs()
@@ -513,7 +514,7 @@ func BenchmarkOverlappingRoute(b *testing.B) {
 		require.NoError(b, r.Tree().Handle(route.method, route.path, emptyHandler))
 	}
 
-	req := httptest.NewRequest("GET", "/foo/abc/id:123/xy", nil)
+	req := httptest.NewRequest(http.MethodGet, "/foo/abc/id:123/xy", nil)
 	w := new(mockResponseWriter)
 
 	b.ReportAllocs()
@@ -524,19 +525,38 @@ func BenchmarkOverlappingRoute(b *testing.B) {
 	}
 }
 
+func BenchmarkWithIgnoreTrailingSlash(b *testing.B) {
+	f := New(WithIgnoreTrailingSlash(true))
+	f.MustHandle(http.MethodGet, "/{a}/{b}/e", emptyHandler)
+	f.MustHandle(http.MethodGet, "/{a}/{b}/d", emptyHandler)
+	f.MustHandle(http.MethodGet, "/foo/{b}", emptyHandler)
+	f.MustHandle(http.MethodGet, "/foo/{b}/x/", emptyHandler)
+	f.MustHandle(http.MethodGet, "/foo/{b}/y/", emptyHandler)
+
+	req := httptest.NewRequest(http.MethodGet, "/foo/bar/", nil)
+	w := new(mockResponseWriter)
+
+	b.ReportAllocs()
+	b.ResetTimer()
+
+	for i := 0; i < b.N; i++ {
+		f.ServeHTTP(w, req)
+	}
+}
+
 func BenchmarkStaticParallel(b *testing.B) {
 	r := New()
 	for _, route := range staticRoutes {
 		require.NoError(b, r.Tree().Handle(route.method, route.path, emptyHandler))
 	}
-	benchRouteParallel(b, r, route{"GET", "/progs/image_package4.out"})
+	benchRouteParallel(b, r, route{http.MethodGet, "/progs/image_package4.out"})
 }
 
 func BenchmarkCatchAll(b *testing.B) {
 	r := New()
 	require.NoError(b, r.Tree().Handle(http.MethodGet, "/something/*{args}", emptyHandler))
 	w := new(mockResponseWriter)
-	req := httptest.NewRequest("GET", "/something/awesome", nil)
+	req := httptest.NewRequest(http.MethodGet, "/something/awesome", nil)
 
 	b.ReportAllocs()
 	b.ResetTimer()
@@ -3026,4 +3046,184 @@ func ExampleTree_Has() {
 	tree := f.Tree()
 	exist := tree.Match(http.MethodGet, "/hello/{name}")
 	fmt.Println(exist) // true
+}
+
+// current not a leaf, with leave on incomplete to end of edge
+func TestX(t *testing.T) {
+	f := New()
+	f.MustHandle(http.MethodGet, "/{a}", emptyHandler)
+	f.MustHandle(http.MethodGet, "/foo/{b}", emptyHandler)
+	f.MustHandle(http.MethodGet, "/foo/{b}/x/", emptyHandler)
+	f.MustHandle(http.MethodGet, "/foo/{b}/y/", emptyHandler)
+
+	tree := f.Tree()
+	c := newTestContextTree(tree)
+	nds := tree.nodes.Load()
+	fmt.Println((*nds)[0])
+	n, tsr := tree.lookup((*nds)[0], "/foo/bar/", c, false)
+	fmt.Println(n.path, tsr)
+	fmt.Println(c.params)
+}
+
+// current not a leaf, with leave on incomplete match to middle of edge
+func TestX2(t *testing.T) {
+	f := New()
+	f.MustHandle(http.MethodGet, "/{a}/x", emptyHandler)
+	f.MustHandle(http.MethodGet, "/foo/{b}", emptyHandler)
+	f.MustHandle(http.MethodGet, "/foo/{b}/x/", emptyHandler)
+	f.MustHandle(http.MethodGet, "/foo/{b}/y/", emptyHandler)
+
+	tree := f.Tree()
+	c := newTestContextTree(tree)
+	nds := tree.nodes.Load()
+	fmt.Println((*nds)[0])
+	n, tsr := tree.lookup((*nds)[0], "/foo/bar/", c, false)
+	fmt.Println(n.path, tsr)
+	fmt.Println(c.params)
+}
+
+// current not a leaf, with leave on end mid-edge
+func TestX3(t *testing.T) {
+	f := New()
+	f.MustHandle(http.MethodGet, "/{a}/{b}/e", emptyHandler)
+	f.MustHandle(http.MethodGet, "/foo/{b}", emptyHandler)
+	f.MustHandle(http.MethodGet, "/foo/{b}/x/", emptyHandler)
+	f.MustHandle(http.MethodGet, "/foo/{b}/y/", emptyHandler)
+
+	tree := f.Tree()
+	c := newTestContextTree(tree)
+	nds := tree.nodes.Load()
+	fmt.Println((*nds)[0])
+	n, tsr := tree.lookup((*nds)[0], "/foo/bar/", c, false)
+	fmt.Println(n.path, tsr)
+	fmt.Println(c.params)
+}
+
+// current not a leaf, with leave on not a leaf
+func TestX4(t *testing.T) {
+	f := New()
+	f.MustHandle(http.MethodGet, "/{a}/{b}/e", emptyHandler)
+	f.MustHandle(http.MethodGet, "/{a}/{b}/d", emptyHandler)
+	f.MustHandle(http.MethodGet, "/foo/{b}", emptyHandler)
+	f.MustHandle(http.MethodGet, "/foo/{b}/x/", emptyHandler)
+	f.MustHandle(http.MethodGet, "/foo/{b}/y/", emptyHandler)
+
+	tree := f.Tree()
+	c := newTestContextTree(tree)
+	nds := tree.nodes.Load()
+	fmt.Println((*nds)[0])
+	n, tsr := tree.lookup((*nds)[0], "/foo/bar/", c, false)
+	fmt.Println(n.path, tsr)
+	fmt.Println(c.params)
+}
+
+// mid edge key, add an extra ts
+func TestY(t *testing.T) {
+	f := New()
+	f.MustHandle(http.MethodGet, "/{a}", emptyHandler)
+	f.MustHandle(http.MethodGet, "/foo/{b}/", emptyHandler)
+
+	tree := f.Tree()
+	c := newTestContextTree(tree)
+	nds := tree.nodes.Load()
+	fmt.Println((*nds)[0])
+	n, tsr := tree.lookup((*nds)[0], "/foo/bar", c, false)
+	fmt.Println(n.path, tsr)
+	fmt.Println(c.params)
+}
+
+// mid edge key, remove an extra ts
+func TestZ(t *testing.T) {
+	f := New()
+	f.MustHandle(http.MethodGet, "/{a}", emptyHandler)
+	f.MustHandle(http.MethodGet, "/foo/{b}/baz", emptyHandler)
+	f.MustHandle(http.MethodGet, "/foo/{b}", emptyHandler)
+
+	tree := f.Tree()
+	c := newTestContextTree(tree)
+	nds := tree.nodes.Load()
+	fmt.Println((*nds)[0])
+	n, tsr := tree.lookup((*nds)[0], "/foo/bar/", c, false)
+	fmt.Println(n.path, tsr)
+	fmt.Println(c.params)
+}
+
+// incomplete match end of edge
+func TestW(t *testing.T) {
+	f := New()
+	f.MustHandle(http.MethodGet, "/{a}", emptyHandler)
+	f.MustHandle(http.MethodGet, "/foo/{b}", emptyHandler)
+
+	tree := f.Tree()
+	c := newTestContextTree(tree)
+	nds := tree.nodes.Load()
+	fmt.Println((*nds)[0])
+	n, tsr := tree.lookup((*nds)[0], "/foo/bar/", c, false)
+	fmt.Println(n.path, tsr)
+	fmt.Println(c.params)
+}
+
+// current not a leaf, should empty params
+func TestE(t *testing.T) {
+	f := New()
+	f.MustHandle(http.MethodGet, "/{a}", emptyHandler)
+	f.MustHandle(http.MethodGet, "/foo", emptyHandler)
+	f.MustHandle(http.MethodGet, "/foo/x/", emptyHandler)
+	f.MustHandle(http.MethodGet, "/foo/y/", emptyHandler)
+
+	tree := f.Tree()
+	c := newTestContextTree(tree)
+	nds := tree.nodes.Load()
+	fmt.Println((*nds)[0])
+	n, tsr := tree.lookup((*nds)[0], "/foo/", c, false)
+	fmt.Println(n.path, tsr)
+	fmt.Println(c.params)
+}
+
+func BenchmarkX(b *testing.B) {
+	f := New()
+	tree := f.Tree()
+	c := newTestContextTree(tree)
+	*c.params = append(*c.params,
+		Param{
+			Key:   "foo",
+			Value: "bar",
+		},
+		Param{
+			Key:   "foo",
+			Value: "bar",
+		},
+		Param{
+			Key:   "foo",
+			Value: "bar",
+		},
+		Param{
+			Key:   "foo",
+			Value: "bar",
+		},
+		Param{
+			Key:   "foo",
+			Value: "bar",
+		},
+		Param{
+			Key:   "foo",
+			Value: "bar",
+		},
+	)
+
+	b.ResetTimer()
+	b.ReportAllocs()
+
+	params := make(Params, 0, 2)
+
+	for i := 0; i < b.N; i++ {
+		if len(*c.params) > 2 {
+			params = slices.Grow(params, len(*c.params))
+		}
+		params = params[:len(*c.params)]
+		copy(params, *c.params)
+	}
+
+	*c.params = params
+	fmt.Println(*c.params)
 }

--- a/node.go
+++ b/node.go
@@ -214,7 +214,7 @@ func (n *skippedNodes) pop() skippedNode {
 }
 
 type skippedNode struct {
-	parent    *node
+	n         *node
 	pathIndex int
 	paramCnt  uint32
 	seen      bool

--- a/tree.go
+++ b/tree.go
@@ -106,7 +106,7 @@ func (t *Tree) Has(method, path string) bool {
 
 	c := t.ctx.Get().(*cTx)
 	c.resetNil()
-	n, tsr := t.lookup(nds[index], path, c.params, c.skipNds, true)
+	n, tsr := t.lookup(nds[index], path, c, true)
 	c.Close()
 	if n != nil && !tsr {
 		return n.path == path
@@ -128,7 +128,7 @@ func (t *Tree) Match(method, path string) string {
 
 	c := t.ctx.Get().(*cTx)
 	c.resetNil()
-	n, tsr := t.lookup(nds[index], path, c.params, c.skipNds, true)
+	n, tsr := t.lookup(nds[index], path, c, true)
 	c.Close()
 	if n != nil && (!tsr || t.fox.redirectTrailingSlash || t.fox.ignoreTrailingSlash) {
 		return n.path
@@ -159,7 +159,7 @@ func (t *Tree) Methods(path string) []string {
 		c := t.ctx.Get().(*cTx)
 		c.resetNil()
 		for i := range nds {
-			n, tsr := t.lookup(nds[i], path, c.params, c.skipNds, true)
+			n, tsr := t.lookup(nds[i], path, c, true)
 			if n != nil && (!tsr || t.fox.redirectTrailingSlash || t.fox.ignoreTrailingSlash) {
 				if methods == nil {
 					methods = make([]string, 0)
@@ -198,7 +198,7 @@ func (t *Tree) Lookup(w ResponseWriter, r *http.Request) (handler HandlerFunc, c
 		target = r.URL.RawPath
 	}
 
-	n, tsr := t.lookup(nds[index], target, c.params, c.skipNds, false)
+	n, tsr := t.lookup(nds[index], target, c, false)
 	if n != nil {
 		c.path = n.path
 		return n.handler, c, tsr
@@ -524,7 +524,7 @@ const (
 	bracketDelim = '{'
 )
 
-func (t *Tree) lookup(rootNode *node, path string, params *Params, skipNds *skippedNodes, lazy bool) (n *node, tsr bool) {
+func (t *Tree) lookup(rootNode *node, path string, c *cTx, lazy bool) (n *node, tsr bool) {
 	if len(rootNode.children) == 0 {
 		return nil, false
 	}
@@ -537,7 +537,7 @@ func (t *Tree) lookup(rootNode *node, path string, params *Params, skipNds *skip
 
 	var parent *node
 	current := rootNode.children[0].Load()
-	*skipNds = (*skipNds)[:0]
+	*c.skipNds = (*c.skipNds)[:0]
 
 Walk:
 	for charsMatched < len(path) {
@@ -576,7 +576,7 @@ Walk:
 
 					if !lazy {
 						paramCnt++
-						*params = append(*params, Param{Key: current.key[startKey+1 : charsMatchedInNodeFound-1], Value: path[startPath:charsMatched]})
+						*c.params = append(*c.params, Param{Key: current.key[startKey+1 : charsMatchedInNodeFound-1], Value: path[startPath:charsMatched]})
 					}
 
 					continue
@@ -607,7 +607,7 @@ Walk:
 
 				// The node is also a catch-all, save it as the last fallback.
 				if current.catchAllKey != "" {
-					*skipNds = append(*skipNds, skippedNode{current, charsMatched, paramCnt, true})
+					*c.skipNds = append(*c.skipNds, skippedNode{current, charsMatched, paramCnt, true})
 				}
 
 				idx = current.paramChildIndex
@@ -618,7 +618,7 @@ Walk:
 
 			// Save the node if we need to evaluate the child param or catch-all later
 			if current.paramChildIndex >= 0 || current.catchAllKey != "" {
-				*skipNds = append(*skipNds, skippedNode{current, charsMatched, paramCnt, false})
+				*c.skipNds = append(*c.skipNds, skippedNode{current, charsMatched, paramCnt, false})
 			}
 			parent = current
 			current = current.children[idx].Load()
@@ -626,7 +626,7 @@ Walk:
 	}
 
 	paramCnt = 0
-	hasSkpNds := len(*skipNds) > 0
+	hasSkpNds := len(*c.skipNds) > 0
 
 	if !current.isLeaf() {
 
@@ -657,7 +657,7 @@ Walk:
 		if charsMatchedInNodeFound == len(current.key) {
 			// Exact match, note that if we match a catch-all node
 			if !lazy && current.catchAllKey != "" {
-				*params = append(*params, Param{Key: current.catchAllKey, Value: path[charsMatched:]})
+				*c.params = append(*c.params, Param{Key: current.catchAllKey, Value: path[charsMatched:]})
 				return current, false
 			}
 
@@ -695,7 +695,7 @@ Walk:
 	if charsMatched < len(path) && charsMatchedInNodeFound == len(current.key) {
 		if current.catchAllKey != "" {
 			if !lazy {
-				*params = append(*params, Param{Key: current.catchAllKey, Value: path[charsMatched:]})
+				*c.params = append(*c.params, Param{Key: current.catchAllKey, Value: path[charsMatched:]})
 				return current, false
 			}
 			// Same as exact match, no tsr recommendation
@@ -721,14 +721,14 @@ Walk:
 	// Finally incomplete match to middle of edge
 Backtrack:
 	if hasSkpNds {
-		skipped := skipNds.pop()
+		skipped := c.skipNds.pop()
 		if skipped.parent.paramChildIndex < 0 || skipped.seen {
 			// skipped is catch all
 			current = skipped.parent
-			*params = (*params)[:skipped.paramCnt]
+			*c.params = (*c.params)[:skipped.paramCnt]
 
 			if !lazy {
-				*params = append(*params, Param{Key: current.catchAllKey, Value: path[skipped.pathIndex:]})
+				*c.params = append(*c.params, Param{Key: current.catchAllKey, Value: path[skipped.pathIndex:]})
 
 				return current, false
 			}
@@ -741,13 +741,13 @@ Backtrack:
 		// /foo/{bar}
 		// In this case we evaluate first the child param node and fall back to the catch-all.
 		if skipped.parent.catchAllKey != "" {
-			*skipNds = append(*skipNds, skippedNode{skipped.parent, skipped.pathIndex, skipped.paramCnt, true})
+			*c.skipNds = append(*c.skipNds, skippedNode{skipped.parent, skipped.pathIndex, skipped.paramCnt, true})
 		}
 
 		parent = skipped.parent
 		current = skipped.parent.children[skipped.parent.paramChildIndex].Load()
 
-		*params = (*params)[:skipped.paramCnt]
+		*c.params = (*c.params)[:skipped.paramCnt]
 		charsMatched = skipped.pathIndex
 		goto Walk
 	}


### PR DESCRIPTION
````
goos: linux
goarch: amd64
pkg: github.com/tigerwill90/fox
cpu: Intel(R) Core(TM) i9-9900K CPU @ 3.60GHz
                    │   old.txt   │              new.txt               │
                    │   sec/op    │   sec/op     vs base               │
StaticAll-16          11.36µ ± 2%   11.01µ ± 1%  -3.01% (p=0.000 n=10)
GithubParamsAll-16    84.29n ± 1%   82.11n ± 1%  -2.58% (p=0.000 n=10)
OverlappingRoute-16   96.45n ± 1%   98.48n ± 2%  +2.10% (p=0.007 n=10)
StaticParallel-16     9.398n ± 4%   9.521n ± 1%       ~ (p=0.239 n=10)
CatchAll-16           34.06n ± 6%   31.56n ± 2%  -7.34% (p=0.000 n=10)
CatchAllParallel-16   5.732n ± 7%   5.803n ± 6%       ~ (p=0.529 n=10)
CloneWith-16          65.94n ± 1%   66.19n ± 2%       ~ (p=0.684 n=10)
geomean               73.11n        72.25n       -1.18%
````