### PR TITLE
Wildcard lookup optimization

### DIFF
--- a/context.go
+++ b/context.go
@@ -315,7 +315,7 @@ func (c *cTx) CloneWith(w ResponseWriter, r *http.Request) ContextCloser {
 	cp.cachedQuery = nil
 	if cap(*c.params) > cap(*cp.params) {
 		// Grow cp.params to a least cap(c.params)
-		*cp.params = slices.Grow(*cp.params, cap(*c.params)-cap(*cp.params))
+		*cp.params = slices.Grow(*cp.params, cap(*c.params))
 	}
 	// cap(cp.params) >= cap(c.params)
 	// now constraint into len(c.params) & cap(c.params)

--- a/fox_test.go
+++ b/fox_test.go
@@ -3023,6 +3023,17 @@ func atomicSync() (start func(), wait func()) {
 	return
 }
 
+func TestNode_String(t *testing.T) {
+	f := New()
+	require.NoError(t, f.Handle(http.MethodGet, "/foo/{bar}/*{baz}", emptyHandler))
+	tree := f.Tree()
+	nds := *tree.nodes.Load()
+
+	want := `path: GET
+      path: /foo/{bar}/ [catchAll] [leaf=/foo/{bar}/*{baz}] [bar (10)]`
+	assert.Equal(t, want, strings.TrimSuffix(nds[0].String(), "\n"))
+}
+
 // This example demonstrates how to create a simple router using the default options,
 // which include the Recovery and Logger middleware. A basic route is defined, along with a
 // custom middleware to log the request metrics.

--- a/fox_test.go
+++ b/fox_test.go
@@ -507,6 +507,20 @@ func BenchmarkGithubParamsAll(b *testing.B) {
 	}
 }
 
+func BenchmarkLongParam(b *testing.B) {
+	r := New()
+	r.MustHandle(http.MethodGet, "/foo/{very_very_very_very_very_long_param}", emptyHandler)
+	req := httptest.NewRequest(http.MethodGet, "/foo/bar", nil)
+	w := new(mockResponseWriter)
+
+	b.ReportAllocs()
+	b.ResetTimer()
+
+	for i := 0; i < b.N; i++ {
+		r.ServeHTTP(w, req)
+	}
+}
+
 func BenchmarkOverlappingRoute(b *testing.B) {
 	r := New()
 	for _, route := range overlappingRoutes {

--- a/node.go
+++ b/node.go
@@ -278,8 +278,6 @@ func parseWildcard(segment string) []param {
 	for i < len(segment) {
 		switch state {
 		case stateParam:
-			seg := string(segment[i])
-			_ = seg
 			if segment[i] == '}' {
 				end := -1
 				if len(segment[i+1:]) > 0 {
@@ -293,32 +291,28 @@ func parseWildcard(segment string) []param {
 				state = stateDefault
 			}
 			i++
-		case stateCatchAll:
-			seg := string(segment[i])
-			_ = seg
-			if segment[i] == '}' {
-				end := -1
-				if len(segment[i+1:]) > 0 {
-					end = i + 1
-				}
-				params = append(params, param{
-					key:      segment[start:i],
-					end:      end,
-					catchAll: true,
-				})
-				start = 0
-				state = stateDefault
-			}
-			i++
+			//case stateCatchAll:
+			//if segment[i] == '}' {
+			//	end := -1
+			//	if len(segment[i+1:]) > 0 {
+			//		end = i + 1
+			//	}
+			//	params = append(params, param{
+			//		key:      segment[start:i],
+			//		end:      end,
+			//		catchAll: true,
+			//	})
+			//	start = 0
+			//	state = stateDefault
+			//}
+			//i++
 		default:
-			seg := string(segment[i])
-			_ = seg
-			if segment[i] == '*' {
-				state = stateCatchAll
-				i += 2
-				start = i
-				continue
-			}
+			//	if segment[i] == '*' {
+			//	state = stateCatchAll
+			//	i += 2
+			//	start = i
+			//	continue
+			//}
 
 			if segment[i] == '{' {
 				state = stateParam

--- a/node.go
+++ b/node.go
@@ -264,9 +264,9 @@ func appendCatchAll(path, catchAllKey string) string {
 
 // param represents a parsed parameter and its end position in the path.
 type param struct {
-	key      string
-	end      int // -1 if end with {a}, else pos of the next char
-	catchAll bool
+	key string
+	end int // -1 if end with {a}, else pos of the next char
+	// catchAll bool
 }
 
 func parseWildcard(segment string) []param {

--- a/node.go
+++ b/node.go
@@ -36,6 +36,8 @@ type node struct {
 	// each pointer reference to a new child node starting with the same character.
 	children []atomic.Pointer[node]
 
+	params []param
+
 	// The index of a paramChild if any, -1 if none (per rules, only one paramChildren is allowed).
 	paramChildIndex int
 }
@@ -60,7 +62,7 @@ func newNode(key string, handler HandlerFunc, children []*node, catchAllKey stri
 }
 
 func newNodeFromRef(key string, handler HandlerFunc, children []atomic.Pointer[node], childKeys []byte, catchAllKey string, childIndex int, path string) *node {
-	n := &node{
+	return &node{
 		key:             key,
 		childKeys:       childKeys,
 		children:        children,
@@ -68,9 +70,8 @@ func newNodeFromRef(key string, handler HandlerFunc, children []atomic.Pointer[n
 		catchAllKey:     catchAllKey,
 		path:            appendCatchAll(path, catchAllKey),
 		paramChildIndex: childIndex,
+		params:          parseWildcard(key),
 	}
-
-	return n
 }
 
 func (n *node) isLeaf() bool {
@@ -79,6 +80,10 @@ func (n *node) isLeaf() bool {
 
 func (n *node) isCatchAll() bool {
 	return n.catchAllKey != ""
+}
+
+func (n *node) hasWildcard() bool {
+	return len(n.params) > 0
 }
 
 func (n *node) getEdge(s byte) *node {
@@ -184,7 +189,21 @@ func (n *node) string(space int) string {
 	if n.paramChildIndex >= 0 {
 		sb.WriteString(" [paramIdx=")
 		sb.WriteString(strconv.Itoa(n.paramChildIndex))
-		sb.WriteString("]")
+		sb.WriteByte(']')
+		if n.hasWildcard() {
+			sb.WriteString(" [")
+			for i, param := range n.params {
+				if i > 0 {
+					sb.WriteByte(',')
+				}
+				sb.WriteString(param.key)
+				sb.WriteString(" (")
+				sb.WriteString(strconv.Itoa(param.end))
+				sb.WriteString(")")
+			}
+			sb.WriteString("]")
+		}
+
 	}
 
 	if n.isCatchAll() {
@@ -194,6 +213,19 @@ func (n *node) string(space int) string {
 		sb.WriteString(" [leaf=")
 		sb.WriteString(n.path)
 		sb.WriteString("]")
+	}
+	if n.hasWildcard() {
+		sb.WriteString(" [")
+		for i, param := range n.params {
+			if i > 0 {
+				sb.WriteByte(',')
+			}
+			sb.WriteString(param.key)
+			sb.WriteString(" (")
+			sb.WriteString(strconv.Itoa(param.end))
+			sb.WriteString(")")
+		}
+		sb.WriteByte(']')
 	}
 
 	sb.WriteByte('\n')
@@ -228,4 +260,75 @@ func appendCatchAll(path, catchAllKey string) string {
 		}
 	}
 	return path
+}
+
+// param represents a parsed parameter and its end position in the path.
+type param struct {
+	key      string
+	end      int // -1 if end with {a}, else pos of the next char
+	catchAll bool
+}
+
+func parseWildcard(segment string) []param {
+	var params []param
+
+	state := stateDefault
+	start := 0
+	i := 0
+	for i < len(segment) {
+		switch state {
+		case stateParam:
+			seg := string(segment[i])
+			_ = seg
+			if segment[i] == '}' {
+				end := -1
+				if len(segment[i+1:]) > 0 {
+					end = i + 1
+				}
+				params = append(params, param{
+					key: segment[start:i],
+					end: end,
+				})
+				start = 0
+				state = stateDefault
+			}
+			i++
+		case stateCatchAll:
+			seg := string(segment[i])
+			_ = seg
+			if segment[i] == '}' {
+				end := -1
+				if len(segment[i+1:]) > 0 {
+					end = i + 1
+				}
+				params = append(params, param{
+					key:      segment[start:i],
+					end:      end,
+					catchAll: true,
+				})
+				start = 0
+				state = stateDefault
+			}
+			i++
+		default:
+			seg := string(segment[i])
+			_ = seg
+			if segment[i] == '*' {
+				state = stateCatchAll
+				i += 2
+				start = i
+				continue
+			}
+
+			if segment[i] == '{' {
+				state = stateParam
+				i++
+				start = i
+				continue
+			}
+			i++
+		}
+	}
+
+	return params
 }

--- a/tree.go
+++ b/tree.go
@@ -651,7 +651,7 @@ Walk:
 				if !lazy {
 					if cap(*c.params) > cap(*c.tsrParams) {
 						// Grow c.tsrParams to a least cap(c.params)
-						*c.tsrParams = slices.Grow(*c.tsrParams, cap(*c.params)-cap(*c.tsrParams))
+						*c.tsrParams = slices.Grow(*c.tsrParams, cap(*c.params))
 					}
 					// cap(c.tsrParams) >= cap(c.params)
 					// now constraint into len(c.params) & cap(c.params)
@@ -693,7 +693,7 @@ Walk:
 						if !lazy {
 							if cap(*c.params) > cap(*c.tsrParams) {
 								// Grow c.tsrParams to a least cap(c.params)
-								*c.tsrParams = slices.Grow(*c.tsrParams, cap(*c.params)-cap(*c.tsrParams))
+								*c.tsrParams = slices.Grow(*c.tsrParams, cap(*c.params))
 							}
 							// cap(c.tsrParams) >= cap(c.params)
 							// now constraint into len(c.params) & cap(c.params)
@@ -711,7 +711,7 @@ Walk:
 						if !lazy {
 							if cap(*c.params) > cap(*c.tsrParams) {
 								// Grow c.tsrParams to a least cap(c.params)
-								*c.tsrParams = slices.Grow(*c.tsrParams, cap(*c.params)-cap(*c.tsrParams))
+								*c.tsrParams = slices.Grow(*c.tsrParams, cap(*c.params))
 							}
 							// cap(c.tsrParams) >= cap(c.params)
 							// now constraint into len(c.params) & cap(c.params)
@@ -752,7 +752,7 @@ Walk:
 				if !lazy {
 					if cap(*c.params) > cap(*c.tsrParams) {
 						// Grow c.tsrParams to a least cap(c.params)
-						*c.tsrParams = slices.Grow(*c.tsrParams, cap(*c.params)-cap(*c.tsrParams))
+						*c.tsrParams = slices.Grow(*c.tsrParams, cap(*c.params))
 					}
 					// cap(c.tsrParams) >= cap(c.params)
 					// now constraint into len(c.params) & cap(c.params)


### PR DESCRIPTION
This PR improves wildcard route performance by ~10%. Instead of parsing parameters during the lookup phase, parameters are now parsed during the tree-building phase and can be directly retrieved during lookup. Previously, parsing time increased with the size of the wildcard key due to searching for the next '/', which was expensive for very long keys. This issue has been resolved.


### Benchmark Differential
````
goos: linux
goarch: amd64
pkg: github.com/tigerwill90/fox
cpu: Intel(R) Core(TM) i9-9900K CPU @ 3.60GHz
                    │    old.txt    │               new.txt               │
                    │    sec/op     │   sec/op     vs base                │
StaticAll-16           11.17µ ±  2%   10.91µ ± 1%   -2.32% (p=0.000 n=10)
GithubParamsAll-16     84.64n ±  1%   75.31n ± 2%  -11.03% (p=0.000 n=10)
OverlappingRoute-16   100.60n ±  1%   87.16n ± 2%  -13.35% (p=0.000 n=10)
StaticParallel-16      9.518n ±  3%   9.234n ± 3%   -2.98% (p=0.002 n=10)
CatchAll-16            31.97n ±  2%   31.67n ± 4%        ~ (p=0.280 n=10)
CatchAllParallel-16    5.820n ± 16%   5.904n ± 7%        ~ (p=1.000 n=10)
CloneWith-16           67.27n ±  2%   66.33n ± 2%        ~ (p=0.078 n=10)
geomean                73.27n         69.96n        -4.51%
````

And comparing with Gin and Echo for wildcard route:
````
BenchmarkFox_GithubAll-16          70188             16357 ns/op               0 B/op          0 allocs/op
BenchmarkEcho_GithubAll-16         56134             20734 ns/op               0 B/op          0 allocs/op
BenchmarkGin_GithubAll-16          70112             17793 ns/op               0 B/op          0 allocs/op
````
