### PR TITLE
Introducing per route options

### DIFF
--- a/context.go
+++ b/context.go
@@ -86,8 +86,8 @@ type Context interface {
 	Tree() *Tree
 	// Fox returns the Router instance.
 	Fox() *Router
-	// Reset resets the Context to its initial state, attaching the provided ResponseWriter and http.Request.
-	Reset(w ResponseWriter, r *http.Request)
+	// Reset resets the Context to its initial state, attaching the provided Router, ResponseWriter and http.Request.
+	Reset(fox *Router, w ResponseWriter, r *http.Request)
 }
 
 // cTx holds request-related information and allows interaction with the ResponseWriter.
@@ -99,8 +99,7 @@ type cTx struct {
 	skipNds   *skippedNodes
 
 	// tree at allocation (read-only, no reset)
-	tree *Tree
-	// router at allocation (read-only, no reset)
+	tree        *Tree
 	fox         *Router
 	cachedQuery url.Values
 	path        string
@@ -109,25 +108,27 @@ type cTx struct {
 }
 
 // Reset resets the Context to its initial state, attaching the provided ResponseWriter and http.Request.
-func (c *cTx) Reset(w ResponseWriter, r *http.Request) {
+func (c *cTx) Reset(fox *Router, w ResponseWriter, r *http.Request) {
 	c.req = r
 	c.w = w
 	c.path = ""
 	c.tsr = false
 	c.cachedQuery = nil
 	*c.params = (*c.params)[:0]
+	c.fox = fox
 }
 
 // reset resets the Context to its initial state, attaching the provided http.ResponseWriter and http.Request.
 // Caution: You should always pass the original http.ResponseWriter to this method, not the ResponseWriter itself, to
 // avoid wrapping the ResponseWriter within itself. Use wisely!
-func (c *cTx) reset(w http.ResponseWriter, r *http.Request) {
+func (c *cTx) reset(fox *Router, w http.ResponseWriter, r *http.Request) {
 	c.rec.reset(w)
 	c.req = r
 	c.w = &c.rec
 	c.path = ""
 	c.cachedQuery = nil
 	*c.params = (*c.params)[:0]
+	c.fox = fox
 }
 
 func (c *cTx) resetNil() {
@@ -136,6 +137,7 @@ func (c *cTx) resetNil() {
 	c.path = ""
 	c.cachedQuery = nil
 	*c.params = (*c.params)[:0]
+	c.fox = nil
 }
 
 // Request returns the *http.Request.
@@ -313,6 +315,7 @@ func (c *cTx) CloneWith(w ResponseWriter, r *http.Request) ContextCloser {
 	cp.w = w
 	cp.path = c.path
 	cp.cachedQuery = nil
+	cp.fox = c.fox
 	if cap(*c.params) > cap(*cp.params) {
 		// Grow cp.params to a least cap(c.params)
 		*cp.params = slices.Grow(*cp.params, cap(*c.params))

--- a/context.go
+++ b/context.go
@@ -186,8 +186,12 @@ func (c *cTx) RemoteIP() *net.IPAddr {
 // worthy of panicking.
 // This api is EXPERIMENTAL and is likely to change in future release.
 func (c *cTx) ClientIP() (*net.IPAddr, error) {
-	ipStrategy := c.Fox().ipStrategy
-	return ipStrategy.ClientIP(c)
+	// We may be in a handler which does not match a route like NotFound handler.
+	if c.route == nil {
+		ipStrategy := c.fox.ipStrategy
+		return ipStrategy.ClientIP(c)
+	}
+	return c.route.ipStrategy.ClientIP(c)
 }
 
 // Params returns a Params slice containing the matched

--- a/context.go
+++ b/context.go
@@ -97,13 +97,13 @@ type cTx struct {
 	params    *Params
 	tsrParams *Params
 	skipNds   *skippedNodes
+	route     *Route
 
 	// tree at allocation (read-only, no reset)
 	tree *Tree
 	// router at allocation (read-only, no reset)
 	fox         *Router
 	cachedQuery url.Values
-	path        string
 	rec         recorder
 	tsr         bool
 }
@@ -112,9 +112,9 @@ type cTx struct {
 func (c *cTx) Reset(w ResponseWriter, r *http.Request) {
 	c.req = r
 	c.w = w
-	c.path = ""
 	c.tsr = false
 	c.cachedQuery = nil
+	c.route = nil
 	*c.params = (*c.params)[:0]
 }
 
@@ -125,16 +125,16 @@ func (c *cTx) reset(w http.ResponseWriter, r *http.Request) {
 	c.rec.reset(w)
 	c.req = r
 	c.w = &c.rec
-	c.path = ""
 	c.cachedQuery = nil
+	c.route = nil
 	*c.params = (*c.params)[:0]
 }
 
 func (c *cTx) resetNil() {
 	c.req = nil
 	c.w = nil
-	c.path = ""
 	c.cachedQuery = nil
+	c.route = nil
 	*c.params = (*c.params)[:0]
 }
 
@@ -235,7 +235,10 @@ func (c *cTx) Header(key string) string {
 
 // Path returns the registered path for the handler.
 func (c *cTx) Path() string {
-	return c.path
+	if c.route == nil {
+		return ""
+	}
+	return c.route.path
 }
 
 // String sends a formatted string with the specified status code.
@@ -287,10 +290,11 @@ func (c *cTx) Fox() *Router {
 // Any attempt to write on the ResponseWriter will panic with the error ErrDiscardedResponseWriter.
 func (c *cTx) Clone() Context {
 	cp := cTx{
-		rec:  c.rec,
-		req:  c.req.Clone(c.req.Context()),
-		fox:  c.fox,
-		tree: c.tree,
+		rec:   c.rec,
+		req:   c.req.Clone(c.req.Context()),
+		fox:   c.fox,
+		tree:  c.tree,
+		route: c.route,
 	}
 
 	cp.rec.ResponseWriter = noopWriter{c.rec.Header().Clone()}
@@ -311,7 +315,7 @@ func (c *cTx) CloneWith(w ResponseWriter, r *http.Request) ContextCloser {
 	cp := c.tree.ctx.Get().(*cTx)
 	cp.req = r
 	cp.w = w
-	cp.path = c.path
+	cp.route = c.route
 	cp.cachedQuery = nil
 	if cap(*c.params) > cap(*cp.params) {
 		// Grow cp.params to a least cap(c.params)

--- a/fox.go
+++ b/fox.go
@@ -346,9 +346,9 @@ func defaultRedirectTrailingSlashHandler(c Context) {
 
 	var url string
 	if len(req.URL.RawPath) > 0 {
-		url = fixTrailingSlash(req.URL.RawPath)
+		url = FixTrailingSlash(req.URL.RawPath)
 	} else {
-		url = fixTrailingSlash(req.URL.Path)
+		url = FixTrailingSlash(req.URL.Path)
 	}
 
 	if url[len(url)-1] == '/' {

--- a/fox.go
+++ b/fox.go
@@ -395,7 +395,7 @@ func (fox *Router) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 
 	n, tsr = tree.lookup(nds[index], target, c, false)
 	if !tsr && n != nil {
-		c.path = n.route.path
+		c.route = n.route
 		c.tsr = tsr
 		n.route.handler(c)
 		// Put back the context, if not extended more than max params or max depth, allowing
@@ -408,7 +408,7 @@ func (fox *Router) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 
 	if r.Method != http.MethodConnect && r.URL.Path != "/" && tsr {
 		if n.route.ignoreTrailingSlash {
-			c.path = n.route.path
+			c.route = n.route
 			c.tsr = tsr
 			n.route.handler(c)
 			c.Close()

--- a/fox.go
+++ b/fox.go
@@ -282,11 +282,11 @@ func (fox *Router) Remove(method, path string) error {
 }
 
 // Lookup is a helper that calls Tree.Lookup. For more details, refer to Tree.Lookup.
-// It performs a manual route lookup for a given http.Request, returning the matched HandlerFunc along with a ContextCloser,
+// It performs a manual route lookup for a given http.Request, returning the matched Route along with a ContextCloser,
 // and a boolean indicating if a trailing slash action (e.g. redirect) is recommended (tsr). The ContextCloser should always
 // be closed if non-nil.
 // This API is EXPERIMENTAL and is likely to change in future release.
-func (fox *Router) Lookup(w ResponseWriter, r *http.Request) (handler HandlerFunc, cc ContextCloser, tsr bool) {
+func (fox *Router) Lookup(w ResponseWriter, r *http.Request) (route *Route, cc ContextCloser, tsr bool) {
 	tree := fox.tree.Load()
 	return tree.Lookup(w, r)
 }

--- a/fox.go
+++ b/fox.go
@@ -68,6 +68,7 @@ func (f ClientIPStrategyFunc) ClientIP(c Context) (*net.IPAddr, error) {
 }
 
 // Route represent a registered route in the route tree.
+// Most of the Route API is EXPERIMENTAL and is likely to change in future release.
 type Route struct {
 	ipStrategy            ClientIPStrategy
 	base                  HandlerFunc
@@ -81,11 +82,6 @@ type Route struct {
 // Handle calls the base handler with the provided Context.
 func (r *Route) Handle(c Context) {
 	r.base(c)
-}
-
-// HandleWithMiddleware calls the handler with applied middleware using the provided Context.
-func (r *Route) HandleWithMiddleware(c Context) {
-	r.handler(c)
 }
 
 // Path returns the route path.

--- a/fox.go
+++ b/fox.go
@@ -141,9 +141,9 @@ var _ http.Handler = (*Router)(nil)
 func New(opts ...GlobalOption) *Router {
 	r := new(Router)
 
-	r.noRoute = DefaultNotFoundHandler()
-	r.noMethod = DefaultMethodNotAllowedHandler()
-	r.autoOptions = DefaultOptionsHandler()
+	r.noRoute = DefaultNotFoundHandler
+	r.noMethod = DefaultMethodNotAllowedHandler
+	r.autoOptions = DefaultOptionsHandler
 	r.ipStrategy = noClientIPStrategy{}
 
 	for _, opt := range opts {
@@ -322,27 +322,21 @@ Next:
 	return nil
 }
 
-// DefaultNotFoundHandler returns a simple HandlerFunc that replies to each request
+// DefaultNotFoundHandler is a simple HandlerFunc that replies to each request
 // with a “404 page not found” reply.
-func DefaultNotFoundHandler() HandlerFunc {
-	return func(c Context) {
-		http.Error(c.Writer(), "404 page not found", http.StatusNotFound)
-	}
+func DefaultNotFoundHandler(c Context) {
+	http.Error(c.Writer(), "404 page not found", http.StatusNotFound)
 }
 
-// DefaultMethodNotAllowedHandler returns a simple HandlerFunc that replies to each request
+// DefaultMethodNotAllowedHandler is a simple HandlerFunc that replies to each request
 // with a “405 Method Not Allowed” reply.
-func DefaultMethodNotAllowedHandler() HandlerFunc {
-	return func(c Context) {
-		http.Error(c.Writer(), http.StatusText(http.StatusMethodNotAllowed), http.StatusMethodNotAllowed)
-	}
+func DefaultMethodNotAllowedHandler(c Context) {
+	http.Error(c.Writer(), http.StatusText(http.StatusMethodNotAllowed), http.StatusMethodNotAllowed)
 }
 
-// DefaultOptionsHandler returns a simple HandlerFunc that replies to each request with a "200 OK" reply.
-func DefaultOptionsHandler() HandlerFunc {
-	return func(c Context) {
-		c.Writer().WriteHeader(http.StatusOK)
-	}
+// DefaultOptionsHandler is a simple HandlerFunc that replies to each request with a "200 OK" reply.
+func DefaultOptionsHandler(c Context) {
+	c.Writer().WriteHeader(http.StatusOK)
 }
 
 func defaultRedirectTrailingSlashHandler(c Context) {

--- a/fox_test.go
+++ b/fox_test.go
@@ -3163,6 +3163,12 @@ func TestNode_String(t *testing.T) {
 	assert.Equal(t, want, strings.TrimSuffix(nds[0].String(), "\n"))
 }
 
+func TestFixTrailingSlash(t *testing.T) {
+	assert.Equal(t, "/foo/", FixTrailingSlash("/foo"))
+	assert.Equal(t, "/foo", FixTrailingSlash("/foo/"))
+	assert.Equal(t, "/", FixTrailingSlash(""))
+}
+
 // This example demonstrates how to create a simple router using the default options,
 // which include the Recovery and Logger middleware. A basic route is defined, along with a
 // custom middleware to log the request metrics.
@@ -3287,7 +3293,7 @@ func ExampleRouter_Lookup() {
 
 				// Add or remove an extra trailing slash and redirect the client.
 				if route.RedirectTrailingSlashEnabled() {
-					if err := c.Redirect(code, fixTrailingSlash(cleanedPath)); err != nil {
+					if err := c.Redirect(code, FixTrailingSlash(cleanedPath)); err != nil {
 						// Only if not in the range 300..308, so not possible here
 						panic(err)
 					}

--- a/fox_test.go
+++ b/fox_test.go
@@ -1818,7 +1818,7 @@ func TestRouterWithClientIPStrategy(t *testing.T) {
 	require.NotNil(t, rte)
 	assert.False(t, rte.ClientIPStrategyEnabled())
 
-	// On not found handler
+	// On not found handler, fallback to global ip strategy
 	req := httptest.NewRequest(http.MethodGet, "/bar", nil)
 	w := httptest.NewRecorder()
 	f.ServeHTTP(w, req)

--- a/fox_test.go
+++ b/fox_test.go
@@ -1379,6 +1379,18 @@ func TestUpdateConflict(t *testing.T) {
 	}
 }
 
+func TestInvalidRoute(t *testing.T) {
+	f := New()
+	// Invalid route on insert
+	assert.ErrorIs(t, f.Handle("get", "/foo", emptyHandler), ErrInvalidRoute)
+	assert.ErrorIs(t, f.Handle("", "/foo", emptyHandler), ErrInvalidRoute)
+	assert.ErrorIs(t, f.Handle(http.MethodGet, "/foo", nil), ErrInvalidRoute)
+
+	// Invalid route on update
+	assert.ErrorIs(t, f.Update("", "/foo", emptyHandler), ErrInvalidRoute)
+	assert.ErrorIs(t, f.Update(http.MethodGet, "/foo", nil), ErrInvalidRoute)
+}
+
 func TestUpdateRoute(t *testing.T) {
 	cases := []struct {
 		name   string

--- a/helpers.go
+++ b/helpers.go
@@ -27,7 +27,6 @@ func newTextContextOnly(fox *Router, w http.ResponseWriter, r *http.Request) *cT
 	c.req = r
 	c.rec.reset(w)
 	c.w = &c.rec
-	c.fox = fox
 	return c
 }
 

--- a/helpers.go
+++ b/helpers.go
@@ -27,6 +27,7 @@ func newTextContextOnly(fox *Router, w http.ResponseWriter, r *http.Request) *cT
 	c.req = r
 	c.rec.reset(w)
 	c.w = &c.rec
+	c.fox = fox
 	return c
 }
 

--- a/iter.go
+++ b/iter.go
@@ -167,7 +167,7 @@ func (it *Iterator) Next() {
 // Path returns the registered path for the current route.
 func (it *Iterator) Path() string {
 	if it.current != nil {
-		return it.current.path
+		return it.current.route.path
 	}
 	return ""
 }
@@ -180,7 +180,7 @@ func (it *Iterator) Method() string {
 // Handler return the registered handler for the current route.
 func (it *Iterator) Handler() HandlerFunc {
 	if it.current != nil {
-		return it.current.handler
+		return it.current.route.handler
 	}
 	return nil
 }
@@ -221,7 +221,7 @@ func (it *rawIterator) hasNext() bool {
 		it.current = elem
 
 		if it.current.isLeaf() {
-			it.path = elem.path
+			it.path = elem.route.Path()
 			return true
 		}
 	}

--- a/node.go
+++ b/node.go
@@ -134,6 +134,7 @@ func linearSearch(keys []byte, s byte) int {
 func binarySearch(keys []byte, s byte) int {
 	low, high := 0, len(keys)-1
 	for low <= high {
+		// nolint:gosec
 		mid := int(uint(low+high) >> 1) // avoid overflow
 		cmp := compare(keys[mid], s)
 		if cmp < 0 {

--- a/node.go
+++ b/node.go
@@ -5,7 +5,8 @@
 package fox
 
 import (
-	"sort"
+	"cmp"
+	"slices"
 	"strconv"
 	"strings"
 	"sync/atomic"
@@ -40,12 +41,8 @@ type node struct {
 }
 
 func newNode(key string, route *Route, children []*node, catchAllKey string) *node {
-	// TODO use this instead of old sort.Slice
-	/*	slices.SortFunc(children, func(a, b *node) int {
+	slices.SortFunc(children, func(a, b *node) int {
 		return cmp.Compare(a.key, b.key)
-	})*/
-	sort.Slice(children, func(i, j int) bool {
-		return children[i].key < children[j].key
 	})
 	nds := make([]atomic.Pointer[node], len(children))
 	childKeys := make([]byte, len(children))

--- a/options.go
+++ b/options.go
@@ -41,8 +41,10 @@ func (o globOptionFunc) applyGlob(r *Router) {
 	o(r)
 }
 
+// nolint:unused
 type pathOptionFunc func(*Route)
 
+// nolint:unused
 func (o pathOptionFunc) applyPath(r *Route) {
 	o(r)
 }

--- a/options.go
+++ b/options.go
@@ -86,7 +86,6 @@ func WithNoMethodHandler(handler HandlerFunc) GlobalOption {
 // respond with a 200 OK status code. The "Allow" header it automatically set before calling the handler. Note that custom OPTIONS
 // handler take priority over automatic replies. By default, DefaultOptionsHandler is used. Note that this option
 // automatically enable WithAutoOptions.
-// This api is EXPERIMENTAL and is likely to change in future release.
 func WithOptionsHandler(handler HandlerFunc) GlobalOption {
 	return globOptionFunc(func(r *Router) {
 		if handler != nil {
@@ -96,9 +95,16 @@ func WithOptionsHandler(handler HandlerFunc) GlobalOption {
 	})
 }
 
-// WithMiddleware attaches a middleware to the router or a path. Middlewares provided will be chained in the order they
-// were added. Note that this option, when used globally, apply middleware to all handler, including NotFound, MethodNotAllowed,
-// AutoOption and the internal redirect handler.
+// WithMiddleware attaches middleware to the router or to a specific route. The middlewares are executed
+// in the order they are added. When applied globally, the middleware affects all handlers, including special handlers
+// such as NotFound, MethodNotAllowed, AutoOption, and the internal redirect handler.
+//
+// This option can be applied on a per-route basis or globally:
+// - If applied globally, the middleware will be applied to all routes and handlers by default.
+// - If applied to a specific route, the middleware will only apply to that route and will be chained after any global middleware.
+//
+// Route-specific middleware must be explicitly reapplied when updating a route. If not, any middleware will be removed,
+// and the route will fall back to using only global middleware (if any).
 func WithMiddleware(m ...MiddlewareFunc) Option {
 	return optionFunc(func(router *Router, route *Route) {
 		if router != nil {
@@ -140,7 +146,7 @@ func WithNoMethod(enable bool) GlobalOption {
 // Use the WithOptionsHandler option to customize the response. When this option is enabled, the router automatically
 // determines the "Allow" header value based on the methods registered for the given route. Note that custom OPTIONS
 // handler take priority over automatic replies. This option is automatically enabled when providing a custom handler with
-// the option WithOptionsHandler. This api is EXPERIMENTAL and is likely to change in future release.
+// the option WithOptionsHandler.
 func WithAutoOptions(enable bool) GlobalOption {
 	return globOptionFunc(func(r *Router) {
 		r.handleOptions = enable
@@ -150,31 +156,58 @@ func WithAutoOptions(enable bool) GlobalOption {
 // WithRedirectTrailingSlash enable automatic redirection fallback when the current request does not match but
 // another handler is found with/without an additional trailing slash. E.g. /foo/bar/ request does not match
 // but /foo/bar would match. The client is redirected with a http status code 301 for GET requests and 308 for
-// all other methods. Note that this option is mutually exclusive with WithIgnoreTrailingSlash, and if both are
-// enabled, WithIgnoreTrailingSlash takes precedence.
+// all other methods.
+//
+// This option can be applied on a per-route basis or globally:
+//   - If applied globally, it affects all routes by default.
+//   - If applied to a specific route, it will override the global setting for that route.
+//   - The option must be explicitly reapplied when updating a route. If not, the route will fall back
+//     to the global configuration for trailing slash behavior.
+//
+// Note that this option is mutually exclusive with WithIgnoreTrailingSlash, and if enabled will
+// automatically deactivate WithIgnoreTrailingSlash.
 func WithRedirectTrailingSlash(enable bool) Option {
 	return optionFunc(func(router *Router, route *Route) {
 		if router != nil {
 			router.redirectTrailingSlash = enable
+			if enable {
+				router.ignoreTrailingSlash = false
+			}
 		}
 		if route != nil {
 			route.redirectTrailingSlash = enable
+			if enable {
+				route.ignoreTrailingSlash = false
+			}
 		}
 	})
 }
 
 // WithIgnoreTrailingSlash allows the router to match routes regardless of whether a trailing slash is present or not.
 // E.g. /foo/bar/ and /foo/bar would both match the same handler. This option prevents the router from issuing
-// a redirect and instead matches the request directly. Note that this option is mutually exclusive with
-// WithRedirectTrailingSlash, and if both are enabled, WithIgnoreTrailingSlash takes precedence.
-// This api is EXPERIMENTAL and is likely to change in future release.
+// a redirect and instead matches the request directly.
+//
+// This option can be applied on a per-route basis or globally:
+//   - If applied globally, it affects all routes by default.
+//   - If applied to a specific route, it will override the global setting for that route.
+//   - The option must be explicitly reapplied when updating a route. If not, the route will fall back
+//     to the global configuration for trailing slash behavior.
+//
+// Note that this option is mutually exclusive with
+// WithRedirectTrailingSlash, and if enabled will automatically deactivate WithRedirectTrailingSlash.
 func WithIgnoreTrailingSlash(enable bool) Option {
 	return optionFunc(func(router *Router, route *Route) {
 		if router != nil {
 			router.ignoreTrailingSlash = enable
+			if enable {
+				router.redirectTrailingSlash = false
+			}
 		}
 		if route != nil {
 			route.ignoreTrailingSlash = enable
+			if enable {
+				route.redirectTrailingSlash = false
+			}
 		}
 	})
 }
@@ -184,7 +217,12 @@ func WithIgnoreTrailingSlash(enable bool) Option {
 // configuration to ensure it never returns an error -- i.e., never fails to find a candidate for the "real" IP.
 // Consequently, getting an error result should be treated as an application error, perhaps even worthy of panicking.
 // There is no sane default, so if no strategy is configured, Context.ClientIP returns ErrNoClientIPStrategy.
-// This API is EXPERIMENTAL and is likely to change in future releases.
+//
+// This option can be applied on a per-route basis or globally:
+//   - If applied globally, it affects all routes by default.
+//   - If applied to a specific route, it will override the global setting for that route.
+//   - The option must be explicitly reapplied when updating a route. If not, the route will fall back
+//     to the global client IP strategy (if one is configured).
 func WithClientIPStrategy(strategy ClientIPStrategy) Option {
 	return optionFunc(func(router *Router, route *Route) {
 		if strategy != nil {

--- a/path.go
+++ b/path.go
@@ -149,7 +149,10 @@ func bufApp(buf *[]byte, s string, w int, c byte) {
 	b[w] = c
 }
 
-func fixTrailingSlash(path string) string {
+// FixTrailingSlash ensures a consistent trailing slash handling for a given path.
+// If the path has more than one character and ends with a slash, it removes the trailing slash.
+// Otherwise, it adds a trailing slash to the path.
+func FixTrailingSlash(path string) string {
 	if len(path) > 1 && path[len(path)-1] == '/' {
 		return path[:len(path)-1]
 	}

--- a/recovery.go
+++ b/recovery.go
@@ -78,7 +78,7 @@ func recovery(logger *slog.Logger, c Context, handle RecoveryFunc) {
 		}
 
 		sb.WriteString("Stack:\n")
-		sb.WriteString(stacktrace(4, 6))
+		sb.WriteString(stacktrace(3, 6))
 
 		params := c.Params()
 		attrs := make([]any, 0, len(params))

--- a/response_writer.go
+++ b/response_writer.go
@@ -162,7 +162,7 @@ func (r *recorder) FlushError() error {
 		flusher.Flush()
 		return nil
 	default:
-		return errNotSupported()
+		return ErrNotSupported()
 	}
 }
 
@@ -181,7 +181,7 @@ func (r *recorder) Hijack() (net.Conn, *bufio.ReadWriter, error) {
 	if hijacker, ok := r.ResponseWriter.(http.Hijacker); ok {
 		return hijacker.Hijack()
 	}
-	return nil, nil, errNotSupported()
+	return nil, nil, ErrNotSupported()
 }
 
 type noUnwrap struct {
@@ -225,6 +225,7 @@ func relevantCaller() runtime.Frame {
 	return frame
 }
 
-func errNotSupported() error {
+// ErrNotSupported returns an error that Is ErrNotSupported, but is not == to it.
+func ErrNotSupported() error {
 	return fmt.Errorf("%w", http.ErrNotSupported)
 }

--- a/strategy/strategy.go
+++ b/strategy/strategy.go
@@ -292,8 +292,8 @@ func (s RightmostTrustedCount) ClientIP(c fox.Context) (*net.IPAddr, error) {
 // attacker creates a CF distribution that points at your origin server. The attacker uses Lambda@Edge to spoof the Host
 // and X-Forwarded-For headers. Now your "trusted" reverse proxy is no longer trustworthy.
 type RightmostTrustedRange struct {
-	headerName string
 	resolver   TrustedIPRange
+	headerName string
 }
 
 // NewRightmostTrustedRange creates a RightmostTrustedRange strategy. headerName must be "X-Forwarded-For"

--- a/tree.go
+++ b/tree.go
@@ -202,7 +202,7 @@ func (t *Tree) Lookup(w ResponseWriter, r *http.Request) (handler HandlerFunc, c
 
 	n, tsr := t.lookup(nds[index], target, c, false)
 	if n != nil {
-		c.path = n.route.path
+		c.route = n.route
 		c.tsr = tsr
 		return n.route.base, c, tsr
 	}

--- a/tree.go
+++ b/tree.go
@@ -57,6 +57,7 @@ func (t *Tree) Handle(method, path string, handler HandlerFunc, opts ...PathOpti
 		return err
 	}
 
+	// nolint:gosec
 	return t.insert(method, p, catchAllKey, uint32(n), t.newRoute(path, handler, opts...))
 }
 

--- a/tree.go
+++ b/tree.go
@@ -176,14 +176,14 @@ func (t *Tree) Methods(path string) []string {
 	return methods
 }
 
-// Lookup performs a manual route lookup for a given http.Request, returning the matched HandlerFunc along with a
+// Lookup performs a manual route lookup for a given http.Request, returning the matched Route along with a
 // ContextCloser, and a boolean indicating if the handler was matched by adding or removing a trailing slash
 // (trailing slash action is recommended). The ContextCloser should always be closed if non-nil. This method is primarily
 // intended for integrating the fox router into custom routing solutions or middleware. This function is safe for concurrent
 // use by multiple goroutine and while mutation on Tree are ongoing. If there is a direct match or a tsr is possible,
-// Lookup always return a HandlerFunc and a ContextCloser.
+// Lookup always return a Route and a ContextCloser.
 // This API is EXPERIMENTAL and is likely to change in future release.
-func (t *Tree) Lookup(w ResponseWriter, r *http.Request) (handler HandlerFunc, cc ContextCloser, tsr bool) {
+func (t *Tree) Lookup(w ResponseWriter, r *http.Request) (route *Route, cc ContextCloser, tsr bool) {
 	nds := *t.nodes.Load()
 	index := findRootNode(r.Method, nds)
 
@@ -204,7 +204,7 @@ func (t *Tree) Lookup(w ResponseWriter, r *http.Request) (handler HandlerFunc, c
 	if n != nil {
 		c.route = n.route
 		c.tsr = tsr
-		return n.route.base, c, tsr
+		return n.route, c, tsr
 	}
 	c.Close()
 	return nil, nil, tsr

--- a/tree.go
+++ b/tree.go
@@ -45,6 +45,9 @@ type Tree struct {
 // for serving requests. However, this function is NOT thread-safe and should be run serially, along with all other
 // Tree APIs that perform write operations. To override an existing route, use Update.
 func (t *Tree) Handle(method, path string, handler HandlerFunc, opts ...PathOption) error {
+	if handler == nil {
+		return fmt.Errorf("%w: nil handler", ErrInvalidRoute)
+	}
 	if matched := regEnLetter.MatchString(method); !matched {
 		return fmt.Errorf("%w: missing or invalid http method", ErrInvalidRoute)
 	}
@@ -62,6 +65,9 @@ func (t *Tree) Handle(method, path string, handler HandlerFunc, opts ...PathOpti
 // serving requests. However, this function is NOT thread-safe and should be run serially, along with all other
 // Tree APIs that perform write operations. To add a new handler, use Handle method.
 func (t *Tree) Update(method, path string, handler HandlerFunc, opts ...PathOption) error {
+	if handler == nil {
+		return fmt.Errorf("%w: nil handler", ErrInvalidRoute)
+	}
 	if method == "" {
 		return fmt.Errorf("%w: missing http method", ErrInvalidRoute)
 	}

--- a/tree.go
+++ b/tree.go
@@ -33,7 +33,7 @@ import (
 type Tree struct {
 	ctx   sync.Pool
 	nodes atomic.Pointer[[]*node]
-	fox   *Router // TODO tree should be agnostic to the router
+	fox   *Router
 	mws   []middleware
 	sync.Mutex
 	maxParams atomic.Uint32
@@ -162,7 +162,7 @@ func (t *Tree) Methods(path string) []string {
 		c.resetNil()
 		for i := range nds {
 			n, tsr := t.lookup(nds[i], path, c, true)
-			if n != nil && (!tsr || t.fox.redirectTrailingSlash || t.fox.ignoreTrailingSlash) {
+			if n != nil && (!tsr || n.route.redirectTrailingSlash || n.route.ignoreTrailingSlash) {
 				if methods == nil {
 					methods = make([]string, 0)
 				}


### PR DESCRIPTION
This PR introduces the ability to enable several previously global options at the route level. Specifically, options like redirecting trailing slashes, ignoring trailing slashes, and configuring the client IP strategy can now be controlled on a per-route basis. Route-specific options take precedence over global options.

Additionally, middleware can now be registered for individual routes. In this case, route-specific middleware will be chained after any global middleware.

When updating a route, all options and middleware must be explicitly reapplied. If not reapplied, the route will default to global options, and any removed options or middleware will not persist. This allows for dynamic enabling/disabling of options as well as middleware update at runtime!

---

### Middleware

In the example below, both `FooHandler` and `BarHandler` use the `Logger` middleware. However, only `FooHandler` has the timeout middleware applied, which is useful for scenarios requiring different middleware configurations on individual routes.

```go
f := fox.New(
	fox.WithMiddleware(fox.Logger()),
)

f.MustHandle(http.MethodGet, "/foo", FooHandler, fox.WithMiddleware(foxtimeout.Middleware(2*time.Second)))
f.MustHandle(http.MethodGet, "/bar", BarHandler)
```

You can also update routes with new middleware:

```go
_ = f.Update(http.MethodGet, "/bar", BarHandler, fox.WithMiddleware(foxtimeout.Middleware(5*time.Second)))
```

Or remove route-specific middleware:

```go
_ = f.Update(http.MethodGet, "/bar", BarHandler)
```

Note that global middleware cannot be removed and does not need to be reapplied on updates.

---

### Client IP Strategy

The client IP strategy can now be set per route, making it ideal for proxies needing custom strategies per endpoint. For instance, different strategies might be required based on network topology.

```go
f.MustHandle(
	http.MethodGet,
	"/iptv-orange",
	OrangeChain,
	fox.WithClientIPStrategy(
		strategy.NewLeftmostNonPrivate(strategy.XForwardedForKey),
	),
)

f.MustHandle(
	http.MethodGet,
	"/tf1-web",
	TF1Chain,
	fox.WithClientIPStrategy(
		strategy.NewRightmostNonPrivate(strategy.XForwardedForKey),
	),
)
```

Route-level strategies take precedence over global strategies and can be updated or removed on a per-route basis. When removed, global strategies will be used.

---

### Trailing Slash Options

Like the client IP strategy, the redirect and ignore trailing slash options can now be enabled or disabled on a per-route basis. Route-level options override global ones.

```go
f := fox.New(
	fox.WithRedirectTrailingSlash(true),
)

f.MustHandle(http.MethodGet, "/foo", FooHandler, fox.WithIgnoreTrailingSlash(true))
f.MustHandle(http.MethodGet, "/bar", BarHandler)
```

You can update the trailing slash behavior for a route as follows:

```go
// Enable trailing slash handling for the route
_ = f.Update(http.MethodGet, "/bar", BarHandler, fox.WithIgnoreTrailingSlash(true))

// Disable trailing slash handling for the route
_ = f.Update(http.MethodGet, "/bar", BarHandler, fox.WithIgnoreTrailingSlash(false))

// Revert to the global option
_ = f.Update(http.MethodGet, "/bar", BarHandler)
```

---
### Other

A new `Tree.Route` method is now available (currently experimental) that allows you to retrieve a registered `Route`, which is also introduced as an experimental feature. `Route` is a new concept introduced (and needed) in this release, designed to encapsulate route-specific configurations.

For example, you can access per-route configuration flags or retrieve the path of a route:

```go
f := fox.New()
f.MustHandle(http.MethodGet, "/bar", BarHandler, fox.WithIgnoreTrailingSlash(true))

tree := f.Tree()
if route := tree.Route(http.MethodGet, "/bar"); route != nil {
	fmt.Println(route.Path())                         // /bar
	fmt.Println(route.IgnoreTrailingSlashEnabled())   // false
	fmt.Println(route.RedirectTrailingSlashEnabled()) // true
	fmt.Println(route.ClientIPStrategyEnabled())      // false
}
```

Knowing which flags are enabled for a route can be useful for building middleware that needs to behave differently based on the configured options.

```go
redirectFixedPath := MiddlewareFunc(func(next HandlerFunc) HandlerFunc {
	return func(c Context) {
		req := c.Request()
		target := req.URL.Path
		cleanedPath := CleanPath(target)

		// Nothing to clean, call next handler.
		if cleanedPath == target {
			next(c)
			return
		}

		req.URL.Path = cleanedPath
		route, cc, tsr := c.Fox().Lookup(c.Writer(), req)
		if route != nil {
			defer cc.Close()

			code := http.StatusMovedPermanently
			if req.Method != http.MethodGet {
				code = http.StatusPermanentRedirect
			}

			// Redirect the client if direct match or indirect match.
			if !tsr || route.IgnoreTrailingSlashEnabled() {
				if err := c.Redirect(code, cleanedPath); err != nil {
					// Only if not in the range 300..308, so not possible here!
					panic(err)
				}
				return
			}

			// Add or remove an extra trailing slash and redirect the client.
			if route.RedirectTrailingSlashEnabled() {
				if err := c.Redirect(code, fixTrailingSlash(cleanedPath)); err != nil {
					// Only if not in the range 300..308, so not possible here
					panic(err)
				}
				return
			}
		}

		// rollback to the original path before calling the
		// next handler or middleware.
		req.URL.Path = target
		next(c)
	}
})
```

The `Route` object also exposes the original handler via `Route.Handle`, which is the handler provided when the route was registered or after an update. This handler is free from any global or route-specific middleware.

This allows, for example to update a route's middleware without needing to store the original handler elsewhere:

```go
tree.Lock()
defer tree.Unlock()

if route := tree.Route(http.MethodGet, "/bar"); route != nil {
	// Update the route using the original handler
	_ = tree.Update(http.MethodGet, "/bar", route.Handle, fox.WithMiddleware(foxtimeout.Middleware(5*time.Second)))
}
```

It is still under consideration whether we should provide access to the handler with all middleware applied (e.g., through `Route.HandleWithMiddleware`). This could be risky, as it may allow users to bypass the rule of explicitly reapplying middleware during route-specific updates, potentially leading to middleware being applied multiple times:

```go
tree.Lock()
defer tree.Unlock()

if route := tree.Route(http.MethodGet, "/bar"); route != nil {
	// Warning: This applies global middleware twice!
	_ = tree.Update(http.MethodGet, "/bar", route.HandleWithMiddleware)
}
```

---

### Breaking Change

The signature of the `Tree.Lookup` and `Router.Lookup` method has changed again. It now returns a `Route` object instead of directly returning a `HandlerFunc`. 

For example:

```go
route, cc, _ := f.Lookup(w, r)
if route != nil {
	defer cc.Close()
	route.Handle(cc) // Use the handler from the route
        return
}
```

The `Lookup` method has undergone several revisions to address various use cases (which is hard).

The signature of the `Tree.Match` method has been updated. It now returns a `Route` and a `tsr` (trailing slash recommendation). The `tsr` flag is `true` if the route was matched by either adding or removing a trailing slash. Similar to the `Lookup` function, this match is performed at no extra cost, as it does not require an additional lookup. `Tree.Match` is more performant than `Tree.Lookup` or `Router.Lookup` because it does not record or parse route parameters during the lookup.

Example:

```go
f := fox.New()
f.MustHandle(http.MethodGet, "/foo/{name}", FooHandler)

tree := f.Tree()
route, tsr := tree.Match(http.MethodGet, "/foo/bar")
if route != nil {
	fmt.Println(route.Path()) // /foo/{name}
	fmt.Println(tsr)          // false
}
```

If the route is matched by removing a trailing slash:

```go
route, tsr = tree.Match(http.MethodGet, "/foo/bar/")
if route != nil {
	fmt.Println(route.Path()) // /foo/{name}
	fmt.Println(tsr)          // true
}
```

If needed, the path can be normalized using the `fox.FixTrailingSlash` function:

```go
fmt.Println(fox.FixTrailingSlash("/foo/bar/")) // /foo/bar
```
---

### Summary

- Route-specific options and middleware can be dynamically applied or removed.
- Route-level settings always take precedence over global settings.
- Middleware and option must be explicitly reapplied on updates, else it fallback on the global configuration
- Global middleware remains unaffected.

### Benchmark Differential
````
goos: linux
goarch: amd64
pkg: github.com/tigerwill90/fox
cpu: Intel(R) Core(TM) i9-9900K CPU @ 3.60GHz
                    │   old.txt   │              new.txt               │
                    │   sec/op    │   sec/op     vs base               │
StaticAll-16          11.34µ ± 2%   11.37µ ± 2%       ~ (p=0.739 n=10)
GithubParamsAll-16    75.22n ± 4%   77.27n ± 2%       ~ (p=0.055 n=10)
OverlappingRoute-16   89.63n ± 1%   89.90n ± 1%       ~ (p=0.089 n=10)
StaticParallel-16     9.404n ± 1%   9.348n ± 2%       ~ (p=0.315 n=10)
CatchAll-16           31.18n ± 2%   31.11n ± 5%       ~ (p=0.782 n=10)
CatchAllParallel-16   5.779n ± 6%   5.796n ± 6%       ~ (p=0.481 n=10)
CloneWith-16          66.04n ± 2%   66.83n ± 1%  +1.20% (p=0.035 n=10)
geomean               70.39n        70.78n       +0.55%

````