### PR TITLE
Allow scope access in handler

### DIFF
--- a/fox_test.go
+++ b/fox_test.go
@@ -6,6 +6,7 @@ package fox
 
 import (
 	"fmt"
+	"github.com/tigerwill90/fox/internal/iterutil"
 	"log"
 	"math/rand"
 	"net"
@@ -638,6 +639,24 @@ func TestStaticRouteMalloc(t *testing.T) {
 		req := httptest.NewRequest(route.method, route.path, nil)
 		w := httptest.NewRecorder()
 		allocs := testing.AllocsPerRun(100, func() { r.ServeHTTP(w, req) })
+		assert.Equal(t, float64(0), allocs)
+	}
+}
+
+func TestRoute_HandleMiddlewareMalloc(t *testing.T) {
+	f := New()
+	for _, rte := range githubAPI {
+		require.NoError(t, f.Tree().Handle(rte.method, rte.path, emptyHandler))
+	}
+
+	for _, rte := range githubAPI {
+		req := httptest.NewRequest(rte.method, rte.path, nil)
+		w := httptest.NewRecorder()
+		r, c, _ := f.Lookup(&recorder{ResponseWriter: w}, req)
+		allocs := testing.AllocsPerRun(100, func() {
+			r.HandleMiddleware(c)
+		})
+		c.Close()
 		assert.Equal(t, float64(0), allocs)
 	}
 }
@@ -2134,7 +2153,7 @@ func TestTree_Remove(t *testing.T) {
 	}
 
 	it := tree.Iter()
-	cnt := len(slices.Collect(right(it.All())))
+	cnt := len(slices.Collect(iterutil.Right(it.All())))
 
 	assert.Equal(t, 0, cnt)
 	assert.Equal(t, 4, len(*tree.nodes.Load()))
@@ -2153,14 +2172,14 @@ func TestTree_Methods(t *testing.T) {
 		require.NoError(t, f.Handle(rte.method, rte.path, emptyHandler))
 	}
 
-	methods := slices.Sorted(left(f.Iter().Reverse(f.Iter().Methods(), "/gists/123/star")))
+	methods := slices.Sorted(iterutil.Left(f.Iter().Reverse(f.Iter().Methods(), "/gists/123/star")))
 	assert.Equal(t, []string{"DELETE", "GET", "PUT"}, methods)
 
 	methods = slices.Sorted(f.Iter().Methods())
 	assert.Equal(t, []string{"DELETE", "GET", "POST", "PUT"}, methods)
 
 	// Ignore trailing slash disable
-	methods = slices.Sorted(left(f.Iter().Reverse(f.Iter().Methods(), "/gists/123/star/")))
+	methods = slices.Sorted(iterutil.Left(f.Iter().Reverse(f.Iter().Methods(), "/gists/123/star/")))
 	assert.Empty(t, methods)
 }
 
@@ -2171,13 +2190,13 @@ func TestTree_MethodsWithIgnoreTsEnable(t *testing.T) {
 		require.NoError(t, f.Handle(method, "/john/doe/", emptyHandler))
 	}
 
-	methods := slices.Sorted(left(f.Iter().Reverse(f.Iter().Methods(), "/foo/bar/")))
+	methods := slices.Sorted(iterutil.Left(f.Iter().Reverse(f.Iter().Methods(), "/foo/bar/")))
 	assert.Equal(t, []string{"DELETE", "GET", "PUT"}, methods)
 
-	methods = slices.Sorted(left(f.Iter().Reverse(f.Iter().Methods(), "/john/doe")))
+	methods = slices.Sorted(iterutil.Left(f.Iter().Reverse(f.Iter().Methods(), "/john/doe")))
 	assert.Equal(t, []string{"DELETE", "GET", "PUT"}, methods)
 
-	methods = slices.Sorted(left(f.Iter().Reverse(f.Iter().Methods(), "/foo/bar/baz")))
+	methods = slices.Sorted(iterutil.Left(f.Iter().Reverse(f.Iter().Methods(), "/foo/bar/baz")))
 	assert.Empty(t, methods)
 }
 
@@ -2391,7 +2410,7 @@ func TestRouterWithAutomaticOptions(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			for _, method := range tc.methods {
 				require.NoError(t, f.Tree().Handle(method, tc.path, func(c Context) {
-					c.SetHeader("Allow", strings.Join(slices.Sorted(left(c.Tree().Iter().Reverse(c.Tree().Iter().Methods(), c.Request().URL.Path))), ", "))
+					c.SetHeader("Allow", strings.Join(slices.Sorted(iterutil.Left(c.Tree().Iter().Reverse(c.Tree().Iter().Methods(), c.Request().URL.Path))), ", "))
 					c.Writer().WriteHeader(http.StatusNoContent)
 				}))
 			}
@@ -2467,7 +2486,7 @@ func TestRouterWithAutomaticOptionsAndIgnoreTsOptionEnable(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			for _, method := range tc.methods {
 				require.NoError(t, f.Tree().Handle(method, tc.path, func(c Context) {
-					c.SetHeader("Allow", strings.Join(slices.Sorted(left(c.Tree().Iter().Reverse(c.Tree().Iter().Methods(), c.Request().URL.Path))), ", "))
+					c.SetHeader("Allow", strings.Join(slices.Sorted(iterutil.Left(c.Tree().Iter().Reverse(c.Tree().Iter().Methods(), c.Request().URL.Path))), ", "))
 					c.Writer().WriteHeader(http.StatusNoContent)
 				}))
 			}
@@ -2512,7 +2531,7 @@ func TestRouterWithAutomaticOptionsAndIgnoreTsOptionDisable(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			for _, method := range tc.methods {
 				require.NoError(t, f.Tree().Handle(method, tc.path, func(c Context) {
-					c.SetHeader("Allow", strings.Join(slices.Sorted(left(c.Tree().Iter().Reverse(c.Tree().Iter().Methods(), c.Request().URL.Path))), ", "))
+					c.SetHeader("Allow", strings.Join(slices.Sorted(iterutil.Left(c.Tree().Iter().Reverse(c.Tree().Iter().Methods(), c.Request().URL.Path))), ", "))
 					c.Writer().WriteHeader(http.StatusNoContent)
 				}))
 			}
@@ -3005,7 +3024,7 @@ func TestFuzzInsertLookupUpdateAndDelete(t *testing.T) {
 	}
 
 	it := tree.Iter()
-	countPath := len(slices.Collect(right(it.All())))
+	countPath := len(slices.Collect(iterutil.Right(it.All())))
 	assert.Equal(t, len(routes), countPath)
 
 	for rte := range routes {
@@ -3027,7 +3046,7 @@ func TestFuzzInsertLookupUpdateAndDelete(t *testing.T) {
 	}
 
 	it = tree.Iter()
-	countPath = len(slices.Collect(right(it.All())))
+	countPath = len(slices.Collect(iterutil.Right(it.All())))
 	assert.Equal(t, 0, countPath)
 }
 

--- a/fox_test.go
+++ b/fox_test.go
@@ -1833,7 +1833,7 @@ func TestRouterWithClientIPStrategy(t *testing.T) {
 	require.NotNil(t, rte)
 	assert.True(t, rte.ClientIPStrategyEnabled())
 
-	require.NoError(t, f.Update(http.MethodGet, "/foo", emptyHandler, WithClientIPStrategy(noClientIPStrategy{})))
+	require.NoError(t, f.Update(http.MethodGet, "/foo", emptyHandler, WithClientIPStrategy(nil)))
 	rte = f.Tree().Route(http.MethodGet, "/foo")
 	require.NotNil(t, rte)
 	assert.False(t, rte.ClientIPStrategyEnabled())

--- a/internal/iterutil/iterutil.go
+++ b/internal/iterutil/iterutil.go
@@ -1,0 +1,33 @@
+package iterutil
+
+import "iter"
+
+func Left[K, V any](seq iter.Seq2[K, V]) iter.Seq[K] {
+	return func(yield func(K) bool) {
+		for k, _ := range seq {
+			if !yield(k) {
+				return
+			}
+		}
+	}
+}
+
+func Right[K, V any](seq iter.Seq2[K, V]) iter.Seq[V] {
+	return func(yield func(V) bool) {
+		for _, v := range seq {
+			if !yield(v) {
+				return
+			}
+		}
+	}
+}
+
+func SeqOf[E any](elems ...E) iter.Seq[E] {
+	return func(yield func(E) bool) {
+		for _, e := range elems {
+			if !yield(e) {
+				return
+			}
+		}
+	}
+}

--- a/iter.go
+++ b/iter.go
@@ -210,33 +210,3 @@ func (it Iter) All() iter.Seq2[string, *Route] {
 		}
 	}
 }
-
-func left[K, V any](seq iter.Seq2[K, V]) iter.Seq[K] {
-	return func(yield func(K) bool) {
-		for k := range seq {
-			if !yield(k) {
-				return
-			}
-		}
-	}
-}
-
-func right[K, V any](seq iter.Seq2[K, V]) iter.Seq[V] {
-	return func(yield func(V) bool) {
-		for _, v := range seq {
-			if !yield(v) {
-				return
-			}
-		}
-	}
-}
-
-func seqOf[E any](elems ...E) iter.Seq[E] {
-	return func(yield func(E) bool) {
-		for _, e := range elems {
-			if !yield(e) {
-				return
-			}
-		}
-	}
-}

--- a/iter_test.go
+++ b/iter_test.go
@@ -8,6 +8,7 @@ import (
 	"fmt"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	"github.com/tigerwill90/fox/internal/iterutil"
 	"net/http"
 	"slices"
 	"testing"
@@ -134,7 +135,7 @@ func TestIter_RootPrefixOneMethod(t *testing.T) {
 	results := make(map[string][]string)
 	it := tree.Iter()
 
-	for method, route := range it.Prefix(seqOf(http.MethodHead), "/") {
+	for method, route := range it.Prefix(iterutil.SeqOf(http.MethodHead), "/") {
 		assert.NotNil(t, route)
 		results[method] = append(results[method], route.Path())
 	}
@@ -169,12 +170,12 @@ func TestIter_EdgeCase(t *testing.T) {
 	tree := New().Tree()
 	it := tree.Iter()
 
-	assert.Empty(t, slices.Collect(left(it.Prefix(seqOf("GET"), "/"))))
-	assert.Empty(t, slices.Collect(left(it.Prefix(seqOf("CONNECT"), "/"))))
-	assert.Empty(t, slices.Collect(left(it.Reverse(seqOf("GET"), "/"))))
-	assert.Empty(t, slices.Collect(left(it.Reverse(seqOf("CONNECT"), "/"))))
-	assert.Empty(t, slices.Collect(left(it.Routes(seqOf("GET"), "/"))))
-	assert.Empty(t, slices.Collect(left(it.Routes(seqOf("CONNECT"), "/"))))
+	assert.Empty(t, slices.Collect(iterutil.Left(it.Prefix(iterutil.SeqOf("GET"), "/"))))
+	assert.Empty(t, slices.Collect(iterutil.Left(it.Prefix(iterutil.SeqOf("CONNECT"), "/"))))
+	assert.Empty(t, slices.Collect(iterutil.Left(it.Reverse(iterutil.SeqOf("GET"), "/"))))
+	assert.Empty(t, slices.Collect(iterutil.Left(it.Reverse(iterutil.SeqOf("CONNECT"), "/"))))
+	assert.Empty(t, slices.Collect(iterutil.Left(it.Routes(iterutil.SeqOf("GET"), "/"))))
+	assert.Empty(t, slices.Collect(iterutil.Left(it.Routes(iterutil.SeqOf("CONNECT"), "/"))))
 }
 
 func TestIter_PrefixWithMethod(t *testing.T) {
@@ -189,7 +190,7 @@ func TestIter_PrefixWithMethod(t *testing.T) {
 	results := make(map[string][]string)
 
 	it := tree.Iter()
-	for method, route := range it.Prefix(seqOf(http.MethodHead), "/foo") {
+	for method, route := range it.Prefix(iterutil.SeqOf(http.MethodHead), "/foo") {
 		assert.NotNil(t, route)
 		results[method] = append(results[method], route.Path())
 	}

--- a/tree.go
+++ b/tree.go
@@ -911,7 +911,7 @@ func (t *Tree) updateMaxDepth(max uint32) {
 func (t *Tree) newRoute(path string, handler HandlerFunc, opts ...PathOption) *Route {
 	rte := &Route{
 		ipStrategy:            t.fox.ipStrategy,
-		base:                  handler,
+		hbase:                 handler,
 		path:                  path,
 		mws:                   t.mws,
 		redirectTrailingSlash: t.fox.redirectTrailingSlash,
@@ -921,7 +921,7 @@ func (t *Tree) newRoute(path string, handler HandlerFunc, opts ...PathOption) *R
 	for _, opt := range opts {
 		opt.applyPath(rte)
 	}
-	rte.handler = applyMiddleware(RouteHandlers, rte.mws, handler)
+	rte.hself, rte.hall = applyRouteMiddleware(rte.mws, handler)
 
 	return rte
 }


### PR DESCRIPTION
### Add Scope Awareness to Middleware and Handlers

This PR introduces scope awareness to middleware and handlers, allowing them to behave differently depending on the context in which they are executed. For instance, consider a middleware that handles path inconsistencies like `/foo////bar`, which cleans up the path and redirects the client to the correct path if it exists. Such middleware would be useful only in the `NoRoute` or `NoMethod` handlers, where requests that don't directly match any route are processed.

Currently, there's a risk that users might mistakenly apply this middleware to all routes, when it should be limited to certain scopes, like:

```go
fox.WithMiddlewareFor(fox.NoMethodHandler | fox.NoRouteHandler, redirectFixedPath)
```

### Example:

The following example demonstrates how to restrict middleware execution to specific scopes:

```go
allowedScope := fox.NoMethodHandler | fox.NoRouteHandler
redirectFixedPath := fox.MiddlewareFunc(func(next fox.HandlerFunc) fox.HandlerFunc {
    return func(c fox.Context) {
        if c.Scope()&allowedScope == 0 {
            log.Println("not in the right scope")
            next(c)
            return
        }

        req := c.Request()
        target := req.URL.Path
        cleanedPath := fox.CleanPath(target)

        if cleanedPath == target {
            next(c)
            return
        }

        req.URL.Path = cleanedPath
        route, cc, tsr := c.Fox().Lookup(c.Writer(), req)
        if route != nil {
            defer cc.Close()

            code := http.StatusMovedPermanently
            if req.Method != http.MethodGet {
                code = http.StatusPermanentRedirect
            }

            if !tsr || route.IgnoreTrailingSlashEnabled() {
                if err := c.Redirect(code, cleanedPath); err != nil {
                    panic(err)
                }
                return
            }

            if route.RedirectTrailingSlashEnabled() {
                if err := c.Redirect(code, fox.FixTrailingSlash(cleanedPath)); err != nil {
                    panic(err)
                }
                return
            }
        }

        req.URL.Path = target
        next(c)
    }
})

f := fox.New(
    // WARNING: Applying middleware globally, including for all scopes.
    fox.WithMiddleware(redirectFixedPath),
)

f.MustHandle(http.MethodGet, "/hello/{name}", func(c fox.Context) {
    _ = c.String(200, "Hello %s\n", c.Param("name"))
})

http.ListenAndServe(":8080", f)
```

Without scope-awareness, the middleware could mistakenly be applied to all routes, causing unnecessary redirection behavior in cases where it's not needed.

### Solution:

With access to the scope inside the handler (`Context.Scope`), middleware can prevent misapplication by checking the scope and logging an error if it's executed in an unintended context:

```go
allowedScope := fox.NoMethodHandler | fox.NoRouteHandler
if c.Scope()&allowedScope == 0 {
    log.Println("not in the right scope")
    next(c)
    return
}
```

### Benefits:

In addition to preventing misapplication, this feature allows middleware like OpenTelemetry to adjust behavior based on context, such as customizing the span name in traces depending on whether the handler is being executed for a route, `NoRoute`, or `NoMethod` handler.