### PR TITLE
Add a basic race detector to detect invalid usage of the tree.

### DIFF
--- a/error.go
+++ b/error.go
@@ -18,6 +18,7 @@ var (
 	ErrDiscardedResponseWriter = errors.New("discarded response writer")
 	ErrInvalidRedirectCode     = errors.New("invalid redirect code")
 	ErrNoClientIPStrategy      = errors.New("no client ip strategy")
+	ErrConcurrentAccess        = errors.New("concurrent access violation: multiple writes detected on tree")
 )
 
 // RouteConflictError is a custom error type used to represent conflicts when


### PR DESCRIPTION
### Introduction 
This PR adds a very basic race detector in order to prevent misuse of the Tree API.

There are multiple comments in the code documenting the correct usage of the Tree. For example:

```
// Tree implements a Concurrent Radix Tree that supports lock-free reads while allowing concurrent writes.
// The caller is responsible for ensuring that all writes are run serially.
```
or in the comment of each write operation:
```
// It's safe to update a handler while the tree is in use for serving requests. However, this function is NOT thread-safe
// and should be run serially, along with all other [Tree] APIs that perform write operations. To add a new handler,
// use [Tree.Handle] method.
```

There is also a whole section in the [README](https://github.com/tigerwill90/fox?tab=readme-ov-file#concurrent-safety-and-proper-usage-of-tree-apis) documenting the correct usage of the `Tree` API.

In complement to the documentation, I propose to add a fail-fast approach, where incorrect usage is detected immediately, allowing developers to fix the issue rather than having subtle race conditions that might be hard to reproduce.

### Implementation
For **insert**, **update**, and **remove** operations, the function body is guarded with this race detector to ensure that these write operations are executed serially, as required by the API’s contract. The implementation is straightforward:
```go
if !t.race.CompareAndSwap(0, 1) {
	panic(ErrConcurrentAccess)
}
defer t.race.Store(0)
```
Since the tree design supports lock-free reads, this mechanism focuses only on write operations. The atomic flag (`t.race`) is only used to guard against concurrent write attempts. Reads remain unaffected by this protection mechanism. The detection itself is just a compare-and-swap operation, which should not introduce any overhead.

We panic instead of returning an error because this misuse represents a fundamental violation of the API’s contract. By panicking, we make it explicitly clear that the code is in an invalid state, enforcing immediate attention and correction (e.g. go native map also detect race condition and panic, this is the same philosophy here). Returning an error could potentially allow the misuse to be ignored or missed, leading to hard-to-debug race conditions that might only manifest under specific circumstances. 