### PR TITLE
Add support for infix wildcard

### DIFF
--- a/README.md
+++ b/README.md
@@ -91,39 +91,57 @@ if errors.Is(err, fox.ErrRouteConflict) {
 ```
 
 #### Named parameters
-A route can be defined using placeholder (e.g `{name}`). The matching segment are recorder into `fox.Param` accessible 
-via `fox.Context`. `fox.Context.Params` provide an iterator to range over `fox.Param` and `fox.Context.Param` allow
-to retrieve directly the value of a parameter using the placeholder name.
+Routes can include named parameters using curly braces `{}` to match exactly one non-empty path segment. The matching 
+segment are recorder into `fox.Param` accessible via `fox.Context`. `fox.Context.Params` provide an iterator to range 
+over `fox.Param` and `fox.Context.Param` allow to retrieve directly the value of a parameter using the placeholder name.
 
 ````
 Pattern /avengers/{name}
 
-/avengers/ironman           match
-/avengers/thor              match
-/avengers/hulk/angry        no match
-/avengers/                  no match
+/avengers/ironman           matches
+/avengers/thor              matches
+/avengers/hulk/angry        no matches
+/avengers/                  no matches
 
 Pattern /users/uuid:{id}
 
-/users/uuid:123             match
-/users/uuid                 no match
+/users/uuid:123             matches
+/users/uuid                 no matches
 ````
 
 #### Catch all parameter
-Catch-all parameters can be used to match everything at the end of a route. The placeholder start with `*` followed by a regular
-named parameter (e.g. `*{name}`).
+Catch-all parameters start with an asterisk `*` followed by a name `{param}` and match one or more non-empty path segments, 
+including slashes. They can be placed anywhere in the route path but **cannot be consecutive**. The matching segment are also 
+accessible via `fox.Context`
+
+**Example with ending catch all**
 ````
 Pattern /src/*{filepath}
 
-/src/                       match
-/src/conf.txt               match
-/src/dir/config.txt         match
+/src/conf.txt               matches
+/src/dir/config.txt         matches
+/src/                       no matches
 
-Patter /src/file=*{path}
+Pattern /src/file=*{path}
 
-/src/file=                  match
-/src/file=config.txt        match
-/src/file=/dir/config.txt   match
+/src/file=config.txt        matches
+/src/file=/dir/config.txt   matches
+/src/file=                  no matches
+````
+
+**Example with infix catch all**
+````
+Pattern: /assets/*{path}/thumbnail
+
+/assets/images/thumbnail            matches
+/assets/photos/2021/thumbnail       matches
+/assets/thumbnail                   no matches
+
+Pattern: /assets/path:*{path}/thumbnail
+
+/assets/path:images/thumbnail       matches
+/assets/path:photos/2021/thumbnail  matches
+/assets/path:thumbnail              no matches
 ````
 
 #### Priority rules
@@ -151,9 +169,17 @@ POST /users/{name}/emails
 
 Additionally, let's consider an example to illustrate the prioritization:
 ````
-GET /fs/avengers.txt    #1 => match /fs/avengers.txt
-GET /fs/{filename}      #2 => match /fs/ironman.txt
-GET /fs/*{filepath}     #3 => match /fs/avengers/ironman.txt
+Route Definitions:
+
+1. GET /fs/avengers.txt          # Highest priority (static)
+2. GET /fs/{filename}            # Next priority (named parameter)
+3. GET /fs/*{filepath}           # Lowest priority (catch-all parameter)
+
+Request Matching:
+
+- /fs/avengers.txt              matches Route 1
+- /fs/ironman.txt               matches Route 2
+- /fs/avengers/ironman.txt      matches Route 3
 ````
 
 #### Warning about context

--- a/README.md
+++ b/README.md
@@ -110,7 +110,7 @@ Pattern /users/uuid:{id}
 ````
 
 #### Catch all parameter
-Catch-all parameters start with an asterisk `*` followed by a name `{param}` and match one or more non-empty path segments, 
+Catch-all parameters start with an asterisk `*` followed by a name `{param}` and match one or more **non-empty** path segments, 
 including slashes. They can be placed anywhere in the route path but **cannot be consecutive**. The matching segment are also 
 accessible via `fox.Context`
 

--- a/context.go
+++ b/context.go
@@ -402,17 +402,6 @@ func (c *cTx) CloneWith(w ResponseWriter, r *http.Request) ContextCloser {
 	return cp
 }
 
-func copyParams(src, dst *Params) {
-	if cap(*src) > cap(*dst) {
-		// Grow dst to a least cap(src)
-		*dst = slices.Grow(*dst, cap(*src))
-	}
-	// cap(dst) >= cap(src)
-	// now constraint into len(src) & cap(src)
-	*dst = (*dst)[:len(*src):cap(*src)]
-	copy(*dst, *src)
-}
-
 // Scope returns the HandlerScope associated with the current Context.
 // This indicates the scope in which the handler is being executed, such as RouteHandler, NoRouteHandler, etc.
 func (c *cTx) Scope() HandlerScope {

--- a/context_test.go
+++ b/context_test.go
@@ -210,11 +210,11 @@ func TestContext_Annotations(t *testing.T) {
 		"/foo",
 		emptyHandler,
 		WithAnnotations(Annotation{Key: "foo", Value: "bar"}, Annotation{Key: "foo", Value: "baz"}),
-		WithAnnotation("john", 1),
+		WithAnnotations(Annotation{Key: "john", Value: 1}),
 	)
 	rte := f.Tree().Route(http.MethodGet, "/foo")
 	require.NotNil(t, rte)
-	assert.Equal(t, []Annotation{{"foo", "bar"}, {"foo", "baz"}, {"john", 1}}, slices.Collect(rte.Annotations()))
+	assert.Equal(t, []Annotation{{Key: "foo", Value: "bar"}, {Key: "foo", Value: "baz"}, {Key: "john", Value: 1}}, slices.Collect(rte.Annotations()))
 }
 
 func TestContext_Clone(t *testing.T) {

--- a/error.go
+++ b/error.go
@@ -32,10 +32,7 @@ type RouteConflictError struct {
 	isUpdate bool
 }
 
-func newConflictErr(method, path, catchAllKey string, matched []string) *RouteConflictError {
-	if catchAllKey != "" {
-		path += "*{" + catchAllKey + "}"
-	}
+func newConflictErr(method, path string, matched []string) *RouteConflictError {
 	return &RouteConflictError{
 		Method:  method,
 		Path:    path,

--- a/fox.go
+++ b/fox.go
@@ -189,9 +189,6 @@ func (fox *Router) NewTree() *Tree {
 			return tree.allocateContext()
 		},
 	}
-	tree.np = sync.Pool{
-		New: func() any { return tree.allocateNode() },
-	}
 
 	return tree
 }

--- a/fox_test.go
+++ b/fox_test.go
@@ -509,6 +509,21 @@ func BenchmarkGithubParamsAll(b *testing.B) {
 	}
 }
 
+func BenchmarkInfixCatchAll(b *testing.B) {
+	f := New()
+	f.MustHandle(http.MethodGet, "/foo/*{bar}/baz", emptyHandler)
+
+	req := httptest.NewRequest(http.MethodGet, "/foo/a1/b22/c333/baz", nil)
+	w := new(mockResponseWriter)
+
+	b.ReportAllocs()
+	b.ResetTimer()
+
+	for i := 0; i < b.N; i++ {
+		f.ServeHTTP(w, req)
+	}
+}
+
 func BenchmarkLongParam(b *testing.B) {
 	r := New()
 	r.MustHandle(http.MethodGet, "/foo/{very_very_very_very_very_long_param}", emptyHandler)

--- a/fox_test.go
+++ b/fox_test.go
@@ -3525,3 +3525,25 @@ func ExampleTree_Has() {
 func onlyError[T any](_ T, err error) error {
 	return err
 }
+
+func TestX(t *testing.T) {
+	f := New(WithIgnoreTrailingSlash(true))
+	tree := f.Tree()
+	// require.NoError(t, tree.insert("GET", "/foo/*{args}", "args", 1, &Route{path: "/foo/*{args}"}))
+	// require.NoError(t, tree.insert("GET", "/foo/", "", 1, &Route{path: "/foo/"}))
+	require.NoError(t, tree.insert("GET", "/foo/*{args}", "", 1, &Route{path: "/foo/*{args}"}))
+	// require.NoError(t, tree.insert("GET", "/{x}/a/b/c/trackk", "", 1, &Route{path: "/{x}/a/b/c/trackk"}))
+
+	nds := *tree.nodes.Load()
+	fmt.Println(nds[0])
+	c := newTestContextTree(tree)
+	n, tsr := tree.lookup(nds[0].children[0].Load(), "/foo/", c, false)
+	fmt.Println("yolo", n, tsr, c.params)
+	// TODO tests
+	// - tsr priority rollback
+	// - wildcard suffix & wildcard infix
+	// - named parameter & wildcard infix
+	// - static & wildcard infix
+	// - empty infix wildcard
+	// current.key[current.params[paramKeyCnt].end:] (OK)
+}

--- a/fox_test.go
+++ b/fox_test.go
@@ -1398,6 +1398,1039 @@ func TestOverlappingRoute(t *testing.T) {
 	}
 }
 
+func TestInfixWildcard(t *testing.T) {
+	cases := []struct {
+		name       string
+		routes     []string
+		path       string
+		wantPath   string
+		wantTsr    bool
+		wantParams []Param
+	}{
+		{
+			name:     "simple infix wildcard",
+			routes:   []string{"/foo/*{args}/bar"},
+			path:     "/foo/a/bar",
+			wantPath: "/foo/*{args}/bar",
+			wantTsr:  false,
+			wantParams: Params{
+				{
+					Key:   "args",
+					Value: "a",
+				},
+			},
+		},
+		{
+			name:     "simple infix wildcard with route char",
+			routes:   []string{"/foo/*{args}/bar"},
+			path:     "/foo/*{args}/bar",
+			wantPath: "/foo/*{args}/bar",
+			wantTsr:  false,
+			wantParams: Params{
+				{
+					Key:   "args",
+					Value: "*{args}",
+				},
+			},
+		},
+		{
+			name:     "simple infix wildcard with multi segment and route char",
+			routes:   []string{"/foo/*{args}/bar"},
+			path:     "/foo/*{args}/b/c/bar",
+			wantPath: "/foo/*{args}/bar",
+			wantTsr:  false,
+			wantParams: Params{
+				{
+					Key:   "args",
+					Value: "*{args}/b/c",
+				},
+			},
+		},
+		{
+			name:     "simple infix inflight wildcard",
+			routes:   []string{"/foo/z*{args}/bar"},
+			path:     "/foo/za/bar",
+			wantPath: "/foo/z*{args}/bar",
+			wantTsr:  false,
+			wantParams: Params{
+				{
+					Key:   "args",
+					Value: "a",
+				},
+			},
+		},
+		{
+			name:     "simple infix inflight wildcard with route char",
+			routes:   []string{"/foo/z*{args}/bar"},
+			path:     "/foo/z*{args}/bar",
+			wantPath: "/foo/z*{args}/bar",
+			wantTsr:  false,
+			wantParams: Params{
+				{
+					Key:   "args",
+					Value: "*{args}",
+				},
+			},
+		},
+		{
+			name:     "simple infix inflight wildcard with multi segment",
+			routes:   []string{"/foo/z*{args}/bar"},
+			path:     "/foo/za/b/c/bar",
+			wantPath: "/foo/z*{args}/bar",
+			wantTsr:  false,
+			wantParams: Params{
+				{
+					Key:   "args",
+					Value: "a/b/c",
+				},
+			},
+		},
+		{
+			name:     "simple infix inflight wildcard with multi segment and route char",
+			routes:   []string{"/foo/z*{args}/bar"},
+			path:     "/foo/z*{args}/b/c/bar",
+			wantPath: "/foo/z*{args}/bar",
+			wantTsr:  false,
+			wantParams: Params{
+				{
+					Key:   "args",
+					Value: "*{args}/b/c",
+				},
+			},
+		},
+		{
+			name:     "simple infix inflight wildcard long",
+			routes:   []string{"/foo/xyz*{args}/bar"},
+			path:     "/foo/xyza/bar",
+			wantPath: "/foo/xyz*{args}/bar",
+			wantTsr:  false,
+			wantParams: Params{
+				{
+					Key:   "args",
+					Value: "a",
+				},
+			},
+		},
+		{
+			name:     "simple infix inflight wildcard with multi segment long",
+			routes:   []string{"/foo/xyz*{args}/bar"},
+			path:     "/foo/xyza/b/c/bar",
+			wantPath: "/foo/xyz*{args}/bar",
+			wantTsr:  false,
+			wantParams: Params{
+				{
+					Key:   "args",
+					Value: "a/b/c",
+				},
+			},
+		},
+		{
+			name:     "overlapping infix and suffix wildcard match infix",
+			routes:   []string{"/foo/*{args}", "/foo/*{args}/bar"},
+			path:     "/foo/a/b/c/bar",
+			wantPath: "/foo/*{args}/bar",
+			wantTsr:  false,
+			wantParams: Params{
+				{
+					Key:   "args",
+					Value: "a/b/c",
+				},
+			},
+		},
+		{
+			name:     "overlapping infix and suffix wildcard match suffix",
+			routes:   []string{"/foo/*{args}", "/foo/*{args}/bar"},
+			path:     "/foo/a/b/c/baz",
+			wantPath: "/foo/*{args}",
+			wantTsr:  false,
+			wantParams: Params{
+				{
+					Key:   "args",
+					Value: "a/b/c/baz",
+				},
+			},
+		},
+		{
+			name:     "overlapping infix and suffix wildcard match suffix",
+			routes:   []string{"/foo/*{args}", "/foo/*{args}/bar"},
+			path:     "/foo/a/b/c/barito",
+			wantPath: "/foo/*{args}",
+			wantTsr:  false,
+			wantParams: Params{
+				{
+					Key:   "args",
+					Value: "a/b/c/barito",
+				},
+			},
+		},
+		{
+			name:     "overlapping infix suffix wildcard and param match infix",
+			routes:   []string{"/foo/*{args}", "/foo/*{args}/bar", "/foo/{ps}/bar"},
+			path:     "/foo/a/b/c/bar",
+			wantPath: "/foo/*{args}/bar",
+			wantTsr:  false,
+			wantParams: Params{
+				{
+					Key:   "args",
+					Value: "a/b/c",
+				},
+			},
+		},
+		{
+			name:     "overlapping infix suffix wildcard and param match suffix",
+			routes:   []string{"/foo/*{args}", "/foo/*{args}/bar", "/foo/{ps}/bar"},
+			path:     "/foo/a/b/c/bili",
+			wantPath: "/foo/*{args}",
+			wantTsr:  false,
+			wantParams: Params{
+				{
+					Key:   "args",
+					Value: "a/b/c/bili",
+				},
+			},
+		},
+		{
+			name:     "overlapping infix suffix wildcard and param match infix",
+			routes:   []string{"/foo/*{args}", "/foo/*{args}/bar", "/foo/{ps}"},
+			path:     "/foo/a/bar",
+			wantPath: "/foo/*{args}/bar",
+			wantTsr:  false,
+			wantParams: Params{
+				{
+					Key:   "args",
+					Value: "a",
+				},
+			},
+		},
+		{
+			name:     "overlapping infix suffix wildcard and param match param",
+			routes:   []string{"/foo/*{args}", "/foo/*{args}/bar", "/foo/{ps}/bar"},
+			path:     "/foo/a/bar",
+			wantPath: "/foo/{ps}/bar",
+			wantTsr:  false,
+			wantParams: Params{
+				{
+					Key:   "ps",
+					Value: "a",
+				},
+			},
+		},
+		{
+			name:     "overlapping infix suffix wildcard and param match suffix",
+			routes:   []string{"/foo/*{args}", "/foo/*{args}/bar", "/foo/{ps}"},
+			path:     "/foo/a/bili",
+			wantPath: "/foo/*{args}",
+			wantTsr:  false,
+			wantParams: Params{
+				{
+					Key:   "args",
+					Value: "a/bili",
+				},
+			},
+		},
+		{
+			name:     "overlapping infix suffix wildcard and param match param",
+			routes:   []string{"/foo/*{args}", "/foo/*{args}/bar", "/foo/{ps}"},
+			path:     "/foo/a",
+			wantPath: "/foo/{ps}",
+			wantTsr:  false,
+			wantParams: Params{
+				{
+					Key:   "ps",
+					Value: "a",
+				},
+			},
+		},
+		{
+			name:     "overlapping infix suffix wildcard and param match param with ts",
+			routes:   []string{"/foo/*{args}", "/foo/*{args}/bar", "/foo/{ps}/"},
+			path:     "/foo/a/",
+			wantPath: "/foo/{ps}/",
+			wantTsr:  false,
+			wantParams: Params{
+				{
+					Key:   "ps",
+					Value: "a",
+				},
+			},
+		},
+		{
+			name:     "overlapping infix suffix wildcard and param match suffix without ts",
+			routes:   []string{"/foo/*{args}", "/foo/*{args}/bar", "/foo/{ps}/"},
+			path:     "/foo/a",
+			wantPath: "/foo/*{args}",
+			wantTsr:  false,
+			wantParams: Params{
+				{
+					Key:   "args",
+					Value: "a",
+				},
+			},
+		},
+		{
+			name:     "overlapping infix suffix wildcard and param match suffix without ts",
+			routes:   []string{"/foo/*{args}", "/foo/*{args}/bar", "/foo/{ps}"},
+			path:     "/foo/a/",
+			wantPath: "/foo/*{args}",
+			wantTsr:  false,
+			wantParams: Params{
+				{
+					Key:   "args",
+					Value: "a/",
+				},
+			},
+		},
+		{
+			name:     "overlapping infix inflight suffix wildcard and param match param",
+			routes:   []string{"/foo/123*{args}", "/foo/123*{args}/bar", "/foo/123{ps}/bar"},
+			path:     "/foo/123a/bar",
+			wantPath: "/foo/123{ps}/bar",
+			wantTsr:  false,
+			wantParams: Params{
+				{
+					Key:   "ps",
+					Value: "a",
+				},
+			},
+		},
+		{
+			name:     "overlapping infix inflight suffix wildcard and param match suffix",
+			routes:   []string{"/foo/123*{args}", "/foo/123*{args}/bar", "/foo/123{ps}"},
+			path:     "/foo/123a/bili",
+			wantPath: "/foo/123*{args}",
+			wantTsr:  false,
+			wantParams: Params{
+				{
+					Key:   "args",
+					Value: "a/bili",
+				},
+			},
+		},
+		{
+			name:     "overlapping infix inflight suffix wildcard and param match param",
+			routes:   []string{"/foo/123*{args}", "/foo/123*{args}/bar", "/foo/123{ps}"},
+			path:     "/foo/123a",
+			wantPath: "/foo/123{ps}",
+			wantTsr:  false,
+			wantParams: Params{
+				{
+					Key:   "ps",
+					Value: "a",
+				},
+			},
+		},
+		{
+			name:     "infix segment followed by param",
+			routes:   []string{"/foo/*{a}/{b}"},
+			path:     "/foo/a/b/c/d",
+			wantPath: "/foo/*{a}/{b}",
+			wantTsr:  false,
+			wantParams: Params{
+				{
+					Key:   "a",
+					Value: "a/b/c",
+				},
+				{
+					Key:   "b",
+					Value: "d",
+				},
+			},
+		},
+		{
+			name:     "infix segment followed by two params",
+			routes:   []string{"/foo/*{a}/{b}/{c}"},
+			path:     "/foo/a/b/c/d",
+			wantPath: "/foo/*{a}/{b}/{c}",
+			wantTsr:  false,
+			wantParams: Params{
+				{
+					Key:   "a",
+					Value: "a/b",
+				},
+				{
+					Key:   "b",
+					Value: "c",
+				},
+				{
+					Key:   "c",
+					Value: "d",
+				},
+			},
+		},
+		{
+			name:     "infix segment followed by one param and one wildcard",
+			routes:   []string{"/foo/*{a}/{b}/*{c}"},
+			path:     "/foo/a/b/c/d",
+			wantPath: "/foo/*{a}/{b}/*{c}",
+			wantTsr:  false,
+			wantParams: Params{
+				{
+					Key:   "a",
+					Value: "a",
+				},
+				{
+					Key:   "b",
+					Value: "b",
+				},
+				{
+					Key:   "c",
+					Value: "c/d",
+				},
+			},
+		},
+		{
+			name:     "param followed by suffix wildcard",
+			routes:   []string{"/foo/{a}/*{b}"},
+			path:     "/foo/a/b/c/d",
+			wantPath: "/foo/{a}/*{b}",
+			wantTsr:  false,
+			wantParams: Params{
+				{
+					Key:   "a",
+					Value: "a",
+				},
+				{
+					Key:   "b",
+					Value: "b/c/d",
+				},
+			},
+		},
+		{
+			name:     "infix inflight segment followed by param",
+			routes:   []string{"/foo/123*{a}/{b}"},
+			path:     "/foo/123a/b/c/d",
+			wantPath: "/foo/123*{a}/{b}",
+			wantTsr:  false,
+			wantParams: Params{
+				{
+					Key:   "a",
+					Value: "a/b/c",
+				},
+				{
+					Key:   "b",
+					Value: "d",
+				},
+			},
+		},
+		{
+			name:     "inflight param followed by suffix wildcard",
+			routes:   []string{"/foo/123{a}/*{b}"},
+			path:     "/foo/123a/b/c/d",
+			wantPath: "/foo/123{a}/*{b}",
+			wantTsr:  false,
+			wantParams: Params{
+				{
+					Key:   "a",
+					Value: "a",
+				},
+				{
+					Key:   "b",
+					Value: "b/c/d",
+				},
+			},
+		},
+		{
+			name:     "multi infix segment simple",
+			routes:   []string{"/foo/*{$1}/bar/*{$2}/baz"},
+			path:     "/foo/a/bar/b/c/d/baz",
+			wantPath: "/foo/*{$1}/bar/*{$2}/baz",
+			wantTsr:  false,
+			wantParams: Params{
+				{
+					Key:   "$1",
+					Value: "a",
+				},
+				{
+					Key:   "$2",
+					Value: "b/c/d",
+				},
+			},
+		},
+		{
+			name:     "multi inflight segment simple",
+			routes:   []string{"/foo/123*{$1}/bar/456*{$2}/baz"},
+			path:     "/foo/123a/bar/456b/c/d/baz",
+			wantPath: "/foo/123*{$1}/bar/456*{$2}/baz",
+			wantTsr:  false,
+			wantParams: Params{
+				{
+					Key:   "$1",
+					Value: "a",
+				},
+				{
+					Key:   "$2",
+					Value: "b/c/d",
+				},
+			},
+		},
+		{
+			name:     "static priority",
+			routes:   []string{"/foo/bar/baz", "/foo/{ps}/baz", "/foo/*{any}/baz"},
+			path:     "/foo/bar/baz",
+			wantPath: "/foo/bar/baz",
+			wantTsr:  false,
+		},
+		{
+			name:     "param priority",
+			routes:   []string{"/foo/bar/baz", "/foo/{ps}/baz", "/foo/*{any}/baz"},
+			path:     "/foo/buzz/baz",
+			wantPath: "/foo/{ps}/baz",
+			wantTsr:  false,
+			wantParams: Params{
+				{
+					Key:   "ps",
+					Value: "buzz",
+				},
+			},
+		},
+		{
+			name:     "fallback catch all",
+			routes:   []string{"/foo/bar/baz", "/foo/{ps}/baz", "/foo/*{any}/baz"},
+			path:     "/foo/a/b/baz",
+			wantPath: "/foo/*{any}/baz",
+			wantTsr:  false,
+			wantParams: Params{
+				{
+					Key:   "any",
+					Value: "a/b",
+				},
+			},
+		},
+		{
+			name: "complex overlapping route with static priority",
+			routes: []string{
+				"/foo/bar/baz/{$1}/jo",
+				"/foo/*{any}/baz/{$1}/jo",
+				"/foo/{ps}/baz/{$1}/jo",
+			},
+			path:     "/foo/bar/baz/1/jo",
+			wantPath: "/foo/bar/baz/{$1}/jo",
+			wantTsr:  false,
+			wantParams: Params{
+				{
+					Key:   "$1",
+					Value: "1",
+				},
+			},
+		},
+		{
+			name: "complex overlapping route with param priority",
+			routes: []string{
+				"/foo/bar/baz/{$1}/jo",
+				"/foo/*{any}/baz/{$1}/jo",
+				"/foo/{ps}/baz/{$1}/jo",
+			},
+			path:     "/foo/bam/baz/1/jo",
+			wantPath: "/foo/{ps}/baz/{$1}/jo",
+			wantTsr:  false,
+			wantParams: Params{
+				{
+					Key:   "ps",
+					Value: "bam",
+				},
+				{
+					Key:   "$1",
+					Value: "1",
+				},
+			},
+		},
+		{
+			name: "complex overlapping route with catch all fallback",
+			routes: []string{
+				"/foo/bar/baz/{$1}/jo",
+				"/foo/*{any}/baz/{$1}/jo",
+				"/foo/{ps}/baz/{$1}/jo",
+			},
+			path:     "/foo/a/b/c/baz/1/jo",
+			wantPath: "/foo/*{any}/baz/{$1}/jo",
+			wantTsr:  false,
+			wantParams: Params{
+				{
+					Key:   "any",
+					Value: "a/b/c",
+				},
+				{
+					Key:   "$1",
+					Value: "1",
+				},
+			},
+		},
+		{
+			name: "complex overlapping route with catch all fallback",
+			routes: []string{
+				"/foo/bar/baz/{$1}/jo",
+				"/foo/*{any}/baz/{$1}/john",
+				"/foo/{ps}/baz/{$1}/johnny",
+			},
+			path:     "/foo/a/baz/1/john",
+			wantPath: "/foo/*{any}/baz/{$1}/john",
+			wantTsr:  false,
+			wantParams: Params{
+				{
+					Key:   "any",
+					Value: "a",
+				},
+				{
+					Key:   "$1",
+					Value: "1",
+				},
+			},
+		},
+		{
+			name: "overlapping static and infix",
+			routes: []string{
+				"/foo/*{any}/baz",
+				"/foo/a/b/baz",
+			},
+			path:     "/foo/a/b/baz",
+			wantPath: "/foo/a/b/baz",
+			wantTsr:  false,
+		},
+		{
+			name: "overlapping static and infix with catch all fallback",
+			routes: []string{
+				"/foo/*{any}/baz",
+				"/foo/a/b/baz",
+			},
+			path:     "/foo/a/b/c/baz",
+			wantPath: "/foo/*{any}/baz",
+			wantTsr:  false,
+			wantParams: Params{
+				{
+					Key:   "any",
+					Value: "a/b/c",
+				},
+			},
+		},
+		{
+			name: "infix wildcard with trailing slash",
+			routes: []string{
+				"/foo/*{any}/",
+			},
+			path:     "/foo/a/b/c/",
+			wantPath: "/foo/*{any}/",
+			wantTsr:  false,
+			wantParams: Params{
+				{
+					Key:   "any",
+					Value: "a/b/c",
+				},
+			},
+		},
+		{
+			name: "overlapping static and infix with most specific",
+			routes: []string{
+				"/foo/*{any}/{a}/ddd/",
+				"/foo/*{any}/bbb/{d}",
+			},
+			path:     "/foo/a/b/c/bbb/ddd/",
+			wantPath: "/foo/*{any}/{a}/ddd/",
+			wantTsr:  false,
+			wantParams: Params{
+				{
+					Key:   "any",
+					Value: "a/b/c",
+				},
+				{
+					Key:   "a",
+					Value: "bbb",
+				},
+			},
+		},
+		{
+			name: "infix wildcard with trailing slash",
+			routes: []string{
+				"/foo/*{any}",
+				"/foo/*{any}/b/",
+				"/foo/*{any}/c/",
+			},
+			path:     "/foo/x/y/z/",
+			wantPath: "/foo/*{any}",
+			wantTsr:  false,
+			wantParams: Params{
+				{
+					Key:   "any",
+					Value: "x/y/z/",
+				},
+			},
+		},
+		{
+			name: "infix wildcard with trailing slash most specific",
+			routes: []string{
+				"/foo/*{any}",
+				"/foo/*{any}/",
+			},
+			path:     "/foo/x/y/z/",
+			wantPath: "/foo/*{any}/",
+			wantTsr:  false,
+			wantParams: Params{
+				{
+					Key:   "any",
+					Value: "x/y/z",
+				},
+			},
+		},
+		{
+			name: "infix wildcard with trailing slash most specific",
+			routes: []string{
+				"/foo/*{any}",
+				"/foo/*{any}/",
+			},
+			path:     "/foo/x/y/z",
+			wantPath: "/foo/*{any}",
+			wantTsr:  false,
+			wantParams: Params{
+				{
+					Key:   "any",
+					Value: "x/y/z",
+				},
+			},
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			f := New()
+			tree := f.Tree()
+			for _, rte := range tc.routes {
+				require.NoError(t, onlyError(tree.Handle(http.MethodGet, rte, emptyHandler)))
+			}
+			nds := *tree.nodes.Load()
+			c := newTestContextTree(tree)
+			n, tsr := tree.lookup(nds[0].children[0].Load(), tc.path, c, false)
+			require.NotNil(t, n)
+			assert.Equal(t, tc.wantPath, n.route.path)
+			assert.Equal(t, tc.wantTsr, tsr)
+			c.tsr = tsr
+			assert.Equal(t, tc.wantParams, slices.Collect(c.Params()))
+
+			fmt.Println(n)
+		})
+	}
+
+}
+
+func TestInfixWildcardTsr(t *testing.T) {
+	cases := []struct {
+		name       string
+		routes     []string
+		path       string
+		wantPath   string
+		wantTsr    bool
+		wantParams []Param
+	}{
+		{
+			name: "infix wildcard with trailing slash and tsr add",
+			routes: []string{
+				"/foo/*{any}/",
+			},
+			path:     "/foo/a/b/c",
+			wantPath: "/foo/*{any}/",
+			wantTsr:  true,
+			wantParams: Params{
+				{
+					Key:   "any",
+					Value: "a/b/c",
+				},
+			},
+		},
+		{
+			name: "infix wildcard with tsr but skipped node match",
+			routes: []string{
+				"/foo/*{any}/",
+				"/{x}/a/b/c",
+			},
+			path:     "/foo/a/b/c",
+			wantPath: "/{x}/a/b/c",
+			wantTsr:  false,
+			wantParams: Params{
+				{
+					Key:   "x",
+					Value: "foo",
+				},
+			},
+		},
+		{
+			name: "infix wildcard with tsr but skipped node does not match",
+			routes: []string{
+				"/foo/*{any}/",
+				"/{x}/a/b/x",
+			},
+			path:     "/foo/a/b/c",
+			wantPath: "/foo/*{any}/",
+			wantTsr:  true,
+			wantParams: Params{
+				{
+					Key:   "any",
+					Value: "a/b/c",
+				},
+			},
+		},
+		{
+			name: "infix wildcard with trailing slash and tsr add",
+			routes: []string{
+				"/foo/*{any}/",
+				"/foo/*{any}/abc",
+				"/foo/*{any}/bcd",
+			},
+			path:     "/foo/a/b/c/abd",
+			wantPath: "/foo/*{any}/",
+			wantTsr:  true,
+			wantParams: Params{
+				{
+					Key:   "any",
+					Value: "a/b/c/abd",
+				},
+			},
+		},
+		{
+			name: "infix wildcard with sub-node tsr add fallback",
+			routes: []string{
+				"/foo/*{any}/{a}/ddd/",
+				"/foo/*{any}/bbb/{d}/foo",
+			},
+			path:     "/foo/a/b/c/bbb/ddd",
+			wantPath: "/foo/*{any}/{a}/ddd/",
+			wantTsr:  true,
+			wantParams: Params{
+				{
+					Key:   "any",
+					Value: "a/b/c",
+				},
+				{
+					Key:   "a",
+					Value: "bbb",
+				},
+			},
+		},
+		{
+			name: "infix wildcard with sub-node tsr at depth 1 but direct match",
+			routes: []string{
+				"/foo/*{any}/c/bbb/",
+				"/foo/*{any}/bbb",
+			},
+			path:     "/foo/a/b/c/bbb",
+			wantPath: "/foo/*{any}/bbb",
+			wantTsr:  false,
+			wantParams: Params{
+				{
+					Key:   "any",
+					Value: "a/b/c",
+				},
+			},
+		},
+		{
+			name: "infix wildcard with sub-node tsr at depth 1 and 2 but direct match",
+			routes: []string{
+				"/foo/*{any}/b/c/bbb/",
+				"/foo/*{any}/c/bbb/",
+				"/foo/*{any}/bbb",
+			},
+			path:     "/foo/a/b/c/bbb",
+			wantPath: "/foo/*{any}/bbb",
+			wantTsr:  false,
+			wantParams: Params{
+				{
+					Key:   "any",
+					Value: "a/b/c",
+				},
+			},
+		},
+		{
+			name: "infix wildcard with sub-node tsr at depth 1 and 2 but fallback first tsr",
+			routes: []string{
+				"/foo/*{any}/b/c/bbb/",
+				"/foo/*{any}/c/bbb/",
+				"/foo/*{any}/bbx",
+			},
+			path:     "/foo/a/b/c/bbb",
+			wantPath: "/foo/*{any}/b/c/bbb/",
+			wantTsr:  true,
+			wantParams: Params{
+				{
+					Key:   "any",
+					Value: "a",
+				},
+			},
+		},
+		{
+			name: "infix wildcard with sub-node tsr at depth 1 and 2 but fallback first tsr",
+			routes: []string{
+				"/foo/*{any}/",
+				"/foo/*{any}/b/c/bbb/",
+				"/foo/*{any}/c/bbb/",
+				"/foo/*{any}/bbx",
+			},
+			path:     "/foo/a/b/c/bbb",
+			wantPath: "/foo/*{any}/b/c/bbb/",
+			wantTsr:  true,
+			wantParams: Params{
+				{
+					Key:   "any",
+					Value: "a",
+				},
+			},
+		},
+		{
+			name: "infix wildcard with depth 0 tsr and sub-node tsr at depth 1 fallback first tsr",
+			routes: []string{
+				"/foo/a/b/c/bbb/",
+				"/foo/*{any}/c/bbb/",
+				"/foo/*{any}/bbx",
+			},
+			path:     "/foo/a/b/c/bbb",
+			wantPath: "/foo/a/b/c/bbb/",
+			wantTsr:  true,
+		},
+		{
+			name: "infix wildcard with depth 0 tsr and sub-node tsr at depth 1 fallback first tsr",
+			routes: []string{
+				"/foo/{first}/b/c/bbb/",
+				"/foo/*{any}/c/bbb/",
+				"/foo/*{any}/bbx",
+			},
+			path:     "/foo/a/b/c/bbb",
+			wantPath: "/foo/{first}/b/c/bbb/",
+			wantTsr:  true,
+			wantParams: Params{
+				{
+					Key:   "first",
+					Value: "a",
+				},
+			},
+		},
+		{
+			name: "multi infix wildcard with sub-node tsr at depth 1 but direct match",
+			routes: []string{
+				"/foo/*{any1}/b/c/*{any2}/d/",
+				"/foo/*{any1}/c/*{any2}/d",
+			},
+			path:     "/foo/a/b/c/x/y/z/d",
+			wantPath: "/foo/*{any1}/c/*{any2}/d",
+			wantTsr:  false,
+			wantParams: Params{
+				{
+					Key:   "any1",
+					Value: "a/b",
+				},
+				{
+					Key:   "any2",
+					Value: "x/y/z",
+				},
+			},
+		},
+		{
+			name: "multi infix wildcard with sub-node tsr at depth 1 and fallback first",
+			routes: []string{
+				"/foo/*{any1}/b/c/*{any2}/d/",
+				"/foo/*{any1}/c/*{any2}/x",
+			},
+			path:     "/foo/a/b/c/x/y/z/d",
+			wantPath: "/foo/*{any1}/b/c/*{any2}/d/",
+			wantTsr:  true,
+			wantParams: Params{
+				{
+					Key:   "any1",
+					Value: "a",
+				},
+				{
+					Key:   "any2",
+					Value: "x/y/z",
+				},
+			},
+		},
+		{
+			name: "multi infix wildcard with sub-node tsr and skipped nodes at depth 1 and fallback first",
+			routes: []string{
+				"/foo/*{any1}/b/c/*{any2}/{a}/",
+				"/foo/*{any1}/b/c/*{any2}/d{a}/",
+				"/foo/*{any1}/b/c/*{any2}/dd/",
+				"/foo/*{any1}/c/*{any2}/x",
+			},
+			path:     "/foo/a/b/c/x/y/z/dd",
+			wantPath: "/foo/*{any1}/b/c/*{any2}/dd/",
+			wantTsr:  true,
+			wantParams: Params{
+				{
+					Key:   "any1",
+					Value: "a",
+				},
+				{
+					Key:   "any2",
+					Value: "x/y/z",
+				},
+			},
+		},
+		{
+			name: "multi infix wildcard with sub-node tsr and skipped nodes at depth 1 and direct match",
+			routes: []string{
+				"/foo/*{any1}/b/c/*{any2}/{a}/",
+				"/foo/*{any1}/b/c/*{any2}/d{a}/",
+				"/foo/*{any1}/b/c/*{any2}/dd/",
+				"/foo/*{any1}/c/*{any2}/x",
+			},
+			path:     "/foo/a/b/c/x/y/z/xd/",
+			wantPath: "/foo/*{any1}/b/c/*{any2}/{a}/",
+			wantTsr:  false,
+			wantParams: Params{
+				{
+					Key:   "any1",
+					Value: "a",
+				},
+				{
+					Key:   "any2",
+					Value: "x/y/z",
+				},
+				{
+					Key:   "a",
+					Value: "xd",
+				},
+			},
+		},
+		{
+			name: "multi infix wildcard with sub-node tsr and skipped nodes at depth 1 with direct match depth 0",
+			routes: []string{
+				"/foo/*{any1}/b/c/*{any2}/{a}/",
+				"/foo/*{any1}/b/c/*{any2}/d{a}/",
+				"/foo/*{any1}/b/c/*{any2}/dd/",
+				"/foo/*{any1}/c/*{any2}/x",
+				"/{a}/*{any1}/c/x/y/z/dd",
+			},
+			path:     "/foo/a/b/c/x/y/z/dd",
+			wantPath: "/{a}/*{any1}/c/x/y/z/dd",
+			wantTsr:  false,
+			wantParams: Params{
+				{
+					Key:   "a",
+					Value: "foo",
+				},
+				{
+					Key:   "any1",
+					Value: "a/b",
+				},
+			},
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			f := New()
+			tree := f.Tree()
+			for _, rte := range tc.routes {
+				require.NoError(t, onlyError(tree.Handle(http.MethodGet, rte, emptyHandler)))
+			}
+			nds := *tree.nodes.Load()
+			c := newTestContextTree(tree)
+			n, tsr := tree.lookup(nds[0].children[0].Load(), tc.path, c, false)
+			require.NotNil(t, n)
+			assert.Equal(t, tc.wantPath, n.route.path)
+			assert.Equal(t, tc.wantTsr, tsr)
+			c.tsr = tsr
+			assert.Equal(t, tc.wantParams, slices.Collect(c.Params()))
+		})
+	}
+}
+
 func TestInsertConflict(t *testing.T) {
 	cases := []struct {
 		name   string
@@ -3692,970 +4725,4 @@ func ExampleTree_Has() {
 
 func onlyError[T any](_ T, err error) error {
 	return err
-}
-
-func TestInfixWildcard(t *testing.T) {
-	cases := []struct {
-		name       string
-		routes     []string
-		path       string
-		wantPath   string
-		wantTsr    bool
-		wantParams []Param
-	}{
-		{
-			name:     "simple infix wildcard",
-			routes:   []string{"/foo/*{args}/bar"},
-			path:     "/foo/a/bar",
-			wantPath: "/foo/*{args}/bar",
-			wantTsr:  false,
-			wantParams: Params{
-				{
-					Key:   "args",
-					Value: "a",
-				},
-			},
-		},
-		{
-			name:     "simple infix wildcard with route char",
-			routes:   []string{"/foo/*{args}/bar"},
-			path:     "/foo/*{args}/bar",
-			wantPath: "/foo/*{args}/bar",
-			wantTsr:  false,
-			wantParams: Params{
-				{
-					Key:   "args",
-					Value: "*{args}",
-				},
-			},
-		},
-		{
-			name:     "simple infix wildcard with multi segment and route char",
-			routes:   []string{"/foo/*{args}/bar"},
-			path:     "/foo/*{args}/b/c/bar",
-			wantPath: "/foo/*{args}/bar",
-			wantTsr:  false,
-			wantParams: Params{
-				{
-					Key:   "args",
-					Value: "*{args}/b/c",
-				},
-			},
-		},
-		{
-			name:     "simple infix inflight wildcard",
-			routes:   []string{"/foo/z*{args}/bar"},
-			path:     "/foo/za/bar",
-			wantPath: "/foo/z*{args}/bar",
-			wantTsr:  false,
-			wantParams: Params{
-				{
-					Key:   "args",
-					Value: "a",
-				},
-			},
-		},
-		{
-			name:     "simple infix inflight wildcard with route char",
-			routes:   []string{"/foo/z*{args}/bar"},
-			path:     "/foo/z*{args}/bar",
-			wantPath: "/foo/z*{args}/bar",
-			wantTsr:  false,
-			wantParams: Params{
-				{
-					Key:   "args",
-					Value: "*{args}",
-				},
-			},
-		},
-		{
-			name:     "simple infix inflight wildcard with multi segment",
-			routes:   []string{"/foo/z*{args}/bar"},
-			path:     "/foo/za/b/c/bar",
-			wantPath: "/foo/z*{args}/bar",
-			wantTsr:  false,
-			wantParams: Params{
-				{
-					Key:   "args",
-					Value: "a/b/c",
-				},
-			},
-		},
-		{
-			name:     "simple infix inflight wildcard with multi segment and route char",
-			routes:   []string{"/foo/z*{args}/bar"},
-			path:     "/foo/z*{args}/b/c/bar",
-			wantPath: "/foo/z*{args}/bar",
-			wantTsr:  false,
-			wantParams: Params{
-				{
-					Key:   "args",
-					Value: "*{args}/b/c",
-				},
-			},
-		},
-		{
-			name:     "simple infix inflight wildcard long",
-			routes:   []string{"/foo/xyz*{args}/bar"},
-			path:     "/foo/xyza/bar",
-			wantPath: "/foo/xyz*{args}/bar",
-			wantTsr:  false,
-			wantParams: Params{
-				{
-					Key:   "args",
-					Value: "a",
-				},
-			},
-		},
-		{
-			name:     "simple infix inflight wildcard with multi segment long",
-			routes:   []string{"/foo/xyz*{args}/bar"},
-			path:     "/foo/xyza/b/c/bar",
-			wantPath: "/foo/xyz*{args}/bar",
-			wantTsr:  false,
-			wantParams: Params{
-				{
-					Key:   "args",
-					Value: "a/b/c",
-				},
-			},
-		},
-		{
-			name:     "overlapping infix and suffix wildcard match infix",
-			routes:   []string{"/foo/*{args}", "/foo/*{args}/bar"},
-			path:     "/foo/a/b/c/bar",
-			wantPath: "/foo/*{args}/bar",
-			wantTsr:  false,
-			wantParams: Params{
-				{
-					Key:   "args",
-					Value: "a/b/c",
-				},
-			},
-		},
-		{
-			name:     "overlapping infix and suffix wildcard match suffix",
-			routes:   []string{"/foo/*{args}", "/foo/*{args}/bar"},
-			path:     "/foo/a/b/c/baz",
-			wantPath: "/foo/*{args}",
-			wantTsr:  false,
-			wantParams: Params{
-				{
-					Key:   "args",
-					Value: "a/b/c/baz",
-				},
-			},
-		},
-		{
-			name:     "overlapping infix and suffix wildcard match suffix",
-			routes:   []string{"/foo/*{args}", "/foo/*{args}/bar"},
-			path:     "/foo/a/b/c/barito",
-			wantPath: "/foo/*{args}",
-			wantTsr:  false,
-			wantParams: Params{
-				{
-					Key:   "args",
-					Value: "a/b/c/barito",
-				},
-			},
-		},
-		{
-			name:     "overlapping infix suffix wildcard and param match infix",
-			routes:   []string{"/foo/*{args}", "/foo/*{args}/bar", "/foo/{ps}/bar"},
-			path:     "/foo/a/b/c/bar",
-			wantPath: "/foo/*{args}/bar",
-			wantTsr:  false,
-			wantParams: Params{
-				{
-					Key:   "args",
-					Value: "a/b/c",
-				},
-			},
-		},
-		{
-			name:     "overlapping infix suffix wildcard and param match suffix",
-			routes:   []string{"/foo/*{args}", "/foo/*{args}/bar", "/foo/{ps}/bar"},
-			path:     "/foo/a/b/c/bili",
-			wantPath: "/foo/*{args}",
-			wantTsr:  false,
-			wantParams: Params{
-				{
-					Key:   "args",
-					Value: "a/b/c/bili",
-				},
-			},
-		},
-		{
-			name:     "overlapping infix suffix wildcard and param match infix",
-			routes:   []string{"/foo/*{args}", "/foo/*{args}/bar", "/foo/{ps}"},
-			path:     "/foo/a/bar",
-			wantPath: "/foo/*{args}/bar",
-			wantTsr:  false,
-			wantParams: Params{
-				{
-					Key:   "args",
-					Value: "a",
-				},
-			},
-		},
-		{
-			name:     "overlapping infix suffix wildcard and param match param",
-			routes:   []string{"/foo/*{args}", "/foo/*{args}/bar", "/foo/{ps}/bar"},
-			path:     "/foo/a/bar",
-			wantPath: "/foo/{ps}/bar",
-			wantTsr:  false,
-			wantParams: Params{
-				{
-					Key:   "ps",
-					Value: "a",
-				},
-			},
-		},
-		{
-			name:     "overlapping infix suffix wildcard and param match suffix",
-			routes:   []string{"/foo/*{args}", "/foo/*{args}/bar", "/foo/{ps}"},
-			path:     "/foo/a/bili",
-			wantPath: "/foo/*{args}",
-			wantTsr:  false,
-			wantParams: Params{
-				{
-					Key:   "args",
-					Value: "a/bili",
-				},
-			},
-		},
-		{
-			name:     "overlapping infix suffix wildcard and param match param",
-			routes:   []string{"/foo/*{args}", "/foo/*{args}/bar", "/foo/{ps}"},
-			path:     "/foo/a",
-			wantPath: "/foo/{ps}",
-			wantTsr:  false,
-			wantParams: Params{
-				{
-					Key:   "ps",
-					Value: "a",
-				},
-			},
-		},
-		{
-			name:     "overlapping infix suffix wildcard and param match param with ts",
-			routes:   []string{"/foo/*{args}", "/foo/*{args}/bar", "/foo/{ps}/"},
-			path:     "/foo/a/",
-			wantPath: "/foo/{ps}/",
-			wantTsr:  false,
-			wantParams: Params{
-				{
-					Key:   "ps",
-					Value: "a",
-				},
-			},
-		},
-		{
-			name:     "overlapping infix suffix wildcard and param match suffix without ts",
-			routes:   []string{"/foo/*{args}", "/foo/*{args}/bar", "/foo/{ps}/"},
-			path:     "/foo/a",
-			wantPath: "/foo/*{args}",
-			wantTsr:  false,
-			wantParams: Params{
-				{
-					Key:   "args",
-					Value: "a",
-				},
-			},
-		},
-		{
-			name:     "overlapping infix suffix wildcard and param match suffix without ts",
-			routes:   []string{"/foo/*{args}", "/foo/*{args}/bar", "/foo/{ps}"},
-			path:     "/foo/a/",
-			wantPath: "/foo/*{args}",
-			wantTsr:  false,
-			wantParams: Params{
-				{
-					Key:   "args",
-					Value: "a/",
-				},
-			},
-		},
-		{
-			name:     "overlapping infix inflight suffix wildcard and param match param",
-			routes:   []string{"/foo/123*{args}", "/foo/123*{args}/bar", "/foo/123{ps}/bar"},
-			path:     "/foo/123a/bar",
-			wantPath: "/foo/123{ps}/bar",
-			wantTsr:  false,
-			wantParams: Params{
-				{
-					Key:   "ps",
-					Value: "a",
-				},
-			},
-		},
-		{
-			name:     "overlapping infix inflight suffix wildcard and param match suffix",
-			routes:   []string{"/foo/123*{args}", "/foo/123*{args}/bar", "/foo/123{ps}"},
-			path:     "/foo/123a/bili",
-			wantPath: "/foo/123*{args}",
-			wantTsr:  false,
-			wantParams: Params{
-				{
-					Key:   "args",
-					Value: "a/bili",
-				},
-			},
-		},
-		{
-			name:     "overlapping infix inflight suffix wildcard and param match param",
-			routes:   []string{"/foo/123*{args}", "/foo/123*{args}/bar", "/foo/123{ps}"},
-			path:     "/foo/123a",
-			wantPath: "/foo/123{ps}",
-			wantTsr:  false,
-			wantParams: Params{
-				{
-					Key:   "ps",
-					Value: "a",
-				},
-			},
-		},
-		{
-			name:     "infix segment followed by param",
-			routes:   []string{"/foo/*{a}/{b}"},
-			path:     "/foo/a/b/c/d",
-			wantPath: "/foo/*{a}/{b}",
-			wantTsr:  false,
-			wantParams: Params{
-				{
-					Key:   "a",
-					Value: "a/b/c",
-				},
-				{
-					Key:   "b",
-					Value: "d",
-				},
-			},
-		},
-		{
-			name:     "infix segment followed by two params",
-			routes:   []string{"/foo/*{a}/{b}/{c}"},
-			path:     "/foo/a/b/c/d",
-			wantPath: "/foo/*{a}/{b}/{c}",
-			wantTsr:  false,
-			wantParams: Params{
-				{
-					Key:   "a",
-					Value: "a/b",
-				},
-				{
-					Key:   "b",
-					Value: "c",
-				},
-				{
-					Key:   "c",
-					Value: "d",
-				},
-			},
-		},
-		{
-			name:     "infix segment followed by one param and one wildcard",
-			routes:   []string{"/foo/*{a}/{b}/*{c}"},
-			path:     "/foo/a/b/c/d",
-			wantPath: "/foo/*{a}/{b}/*{c}",
-			wantTsr:  false,
-			wantParams: Params{
-				{
-					Key:   "a",
-					Value: "a",
-				},
-				{
-					Key:   "b",
-					Value: "b",
-				},
-				{
-					Key:   "c",
-					Value: "c/d",
-				},
-			},
-		},
-		{
-			name:     "param followed by suffix wildcard",
-			routes:   []string{"/foo/{a}/*{b}"},
-			path:     "/foo/a/b/c/d",
-			wantPath: "/foo/{a}/*{b}",
-			wantTsr:  false,
-			wantParams: Params{
-				{
-					Key:   "a",
-					Value: "a",
-				},
-				{
-					Key:   "b",
-					Value: "b/c/d",
-				},
-			},
-		},
-		{
-			name:     "infix inflight segment followed by param",
-			routes:   []string{"/foo/123*{a}/{b}"},
-			path:     "/foo/123a/b/c/d",
-			wantPath: "/foo/123*{a}/{b}",
-			wantTsr:  false,
-			wantParams: Params{
-				{
-					Key:   "a",
-					Value: "a/b/c",
-				},
-				{
-					Key:   "b",
-					Value: "d",
-				},
-			},
-		},
-		{
-			name:     "inflight param followed by suffix wildcard",
-			routes:   []string{"/foo/123{a}/*{b}"},
-			path:     "/foo/123a/b/c/d",
-			wantPath: "/foo/123{a}/*{b}",
-			wantTsr:  false,
-			wantParams: Params{
-				{
-					Key:   "a",
-					Value: "a",
-				},
-				{
-					Key:   "b",
-					Value: "b/c/d",
-				},
-			},
-		},
-		{
-			name:     "multi infix segment simple",
-			routes:   []string{"/foo/*{$1}/bar/*{$2}/baz"},
-			path:     "/foo/a/bar/b/c/d/baz",
-			wantPath: "/foo/*{$1}/bar/*{$2}/baz",
-			wantTsr:  false,
-			wantParams: Params{
-				{
-					Key:   "$1",
-					Value: "a",
-				},
-				{
-					Key:   "$2",
-					Value: "b/c/d",
-				},
-			},
-		},
-		{
-			name:     "multi inflight segment simple",
-			routes:   []string{"/foo/123*{$1}/bar/456*{$2}/baz"},
-			path:     "/foo/123a/bar/456b/c/d/baz",
-			wantPath: "/foo/123*{$1}/bar/456*{$2}/baz",
-			wantTsr:  false,
-			wantParams: Params{
-				{
-					Key:   "$1",
-					Value: "a",
-				},
-				{
-					Key:   "$2",
-					Value: "b/c/d",
-				},
-			},
-		},
-		{
-			name:     "static priority",
-			routes:   []string{"/foo/bar/baz", "/foo/{ps}/baz", "/foo/*{any}/baz"},
-			path:     "/foo/bar/baz",
-			wantPath: "/foo/bar/baz",
-			wantTsr:  false,
-		},
-		{
-			name:     "param priority",
-			routes:   []string{"/foo/bar/baz", "/foo/{ps}/baz", "/foo/*{any}/baz"},
-			path:     "/foo/buzz/baz",
-			wantPath: "/foo/{ps}/baz",
-			wantTsr:  false,
-			wantParams: Params{
-				{
-					Key:   "ps",
-					Value: "buzz",
-				},
-			},
-		},
-		{
-			name:     "fallback catch all",
-			routes:   []string{"/foo/bar/baz", "/foo/{ps}/baz", "/foo/*{any}/baz"},
-			path:     "/foo/a/b/baz",
-			wantPath: "/foo/*{any}/baz",
-			wantTsr:  false,
-			wantParams: Params{
-				{
-					Key:   "any",
-					Value: "a/b",
-				},
-			},
-		},
-		{
-			name: "complex overlapping route with static priority",
-			routes: []string{
-				"/foo/bar/baz/{$1}/jo",
-				"/foo/*{any}/baz/{$1}/jo",
-				"/foo/{ps}/baz/{$1}/jo",
-			},
-			path:     "/foo/bar/baz/1/jo",
-			wantPath: "/foo/bar/baz/{$1}/jo",
-			wantTsr:  false,
-			wantParams: Params{
-				{
-					Key:   "$1",
-					Value: "1",
-				},
-			},
-		},
-		{
-			name: "complex overlapping route with param priority",
-			routes: []string{
-				"/foo/bar/baz/{$1}/jo",
-				"/foo/*{any}/baz/{$1}/jo",
-				"/foo/{ps}/baz/{$1}/jo",
-			},
-			path:     "/foo/bam/baz/1/jo",
-			wantPath: "/foo/{ps}/baz/{$1}/jo",
-			wantTsr:  false,
-			wantParams: Params{
-				{
-					Key:   "ps",
-					Value: "bam",
-				},
-				{
-					Key:   "$1",
-					Value: "1",
-				},
-			},
-		},
-		{
-			name: "complex overlapping route with catch all fallback",
-			routes: []string{
-				"/foo/bar/baz/{$1}/jo",
-				"/foo/*{any}/baz/{$1}/jo",
-				"/foo/{ps}/baz/{$1}/jo",
-			},
-			path:     "/foo/a/b/c/baz/1/jo",
-			wantPath: "/foo/*{any}/baz/{$1}/jo",
-			wantTsr:  false,
-			wantParams: Params{
-				{
-					Key:   "any",
-					Value: "a/b/c",
-				},
-				{
-					Key:   "$1",
-					Value: "1",
-				},
-			},
-		},
-		{
-			name: "complex overlapping route with catch all fallback",
-			routes: []string{
-				"/foo/bar/baz/{$1}/jo",
-				"/foo/*{any}/baz/{$1}/john",
-				"/foo/{ps}/baz/{$1}/johnny",
-			},
-			path:     "/foo/a/baz/1/john",
-			wantPath: "/foo/*{any}/baz/{$1}/john",
-			wantTsr:  false,
-			wantParams: Params{
-				{
-					Key:   "any",
-					Value: "a",
-				},
-				{
-					Key:   "$1",
-					Value: "1",
-				},
-			},
-		},
-		{
-			name: "overlapping static and infix",
-			routes: []string{
-				"/foo/*{any}/baz",
-				"/foo/a/b/baz",
-			},
-			path:     "/foo/a/b/baz",
-			wantPath: "/foo/a/b/baz",
-			wantTsr:  false,
-		},
-		{
-			name: "overlapping static and infix with catch all fallback",
-			routes: []string{
-				"/foo/*{any}/baz",
-				"/foo/a/b/baz",
-			},
-			path:     "/foo/a/b/c/baz",
-			wantPath: "/foo/*{any}/baz",
-			wantTsr:  false,
-			wantParams: Params{
-				{
-					Key:   "any",
-					Value: "a/b/c",
-				},
-			},
-		},
-		{
-			name: "infix wildcard with trailing slash",
-			routes: []string{
-				"/foo/*{any}/",
-			},
-			path:     "/foo/a/b/c/",
-			wantPath: "/foo/*{any}/",
-			wantTsr:  false,
-			wantParams: Params{
-				{
-					Key:   "any",
-					Value: "a/b/c",
-				},
-			},
-		},
-		{
-			name: "overlapping static and infix with most specific",
-			routes: []string{
-				"/foo/*{any}/{a}/ddd/",
-				"/foo/*{any}/bbb/{d}",
-			},
-			path:     "/foo/a/b/c/bbb/ddd/",
-			wantPath: "/foo/*{any}/{a}/ddd/",
-			wantTsr:  false,
-			wantParams: Params{
-				{
-					Key:   "any",
-					Value: "a/b/c",
-				},
-				{
-					Key:   "a",
-					Value: "bbb",
-				},
-			},
-		},
-		{
-			name: "infix wildcard with trailing slash",
-			routes: []string{
-				"/foo/*{any}",
-				"/foo/*{any}/b/",
-				"/foo/*{any}/c/",
-			},
-			path:     "/foo/x/y/z/",
-			wantPath: "/foo/*{any}",
-			wantTsr:  false,
-			wantParams: Params{
-				{
-					Key:   "any",
-					Value: "x/y/z/",
-				},
-			},
-		},
-		{
-			name: "infix wildcard with trailing slash most specific",
-			routes: []string{
-				"/foo/*{any}",
-				"/foo/*{any}/",
-			},
-			path:     "/foo/x/y/z/",
-			wantPath: "/foo/*{any}/",
-			wantTsr:  false,
-			wantParams: Params{
-				{
-					Key:   "any",
-					Value: "x/y/z",
-				},
-			},
-		},
-		{
-			name: "infix wildcard with trailing slash most specific",
-			routes: []string{
-				"/foo/*{any}",
-				"/foo/*{any}/",
-			},
-			path:     "/foo/x/y/z",
-			wantPath: "/foo/*{any}",
-			wantTsr:  false,
-			wantParams: Params{
-				{
-					Key:   "any",
-					Value: "x/y/z",
-				},
-			},
-		},
-	}
-
-	for _, tc := range cases {
-		t.Run(tc.name, func(t *testing.T) {
-			f := New()
-			tree := f.Tree()
-			for _, rte := range tc.routes {
-				require.NoError(t, onlyError(tree.Handle(http.MethodGet, rte, emptyHandler)))
-			}
-			nds := *tree.nodes.Load()
-			c := newTestContextTree(tree)
-			n, tsr := tree.lookup(nds[0].children[0].Load(), tc.path, c, false)
-			require.NotNil(t, n)
-			assert.Equal(t, tc.wantPath, n.route.path)
-			assert.Equal(t, tc.wantTsr, tsr)
-			c.tsr = tsr
-			assert.Equal(t, tc.wantParams, slices.Collect(c.Params()))
-
-			fmt.Println(n)
-		})
-	}
-
-}
-
-func TestInfixWildcardTsr(t *testing.T) {
-	cases := []struct {
-		name       string
-		routes     []string
-		path       string
-		wantPath   string
-		wantTsr    bool
-		wantParams []Param
-	}{
-		{
-			name: "infix wildcard with trailing slash and tsr add",
-			routes: []string{
-				"/foo/*{any}/",
-			},
-			path:     "/foo/a/b/c",
-			wantPath: "/foo/*{any}/",
-			wantTsr:  true,
-			wantParams: Params{
-				{
-					Key:   "any",
-					Value: "a/b/c",
-				},
-			},
-		},
-		{
-			name: "infix wildcard with tsr but skipped node match",
-			routes: []string{
-				"/foo/*{any}/",
-				"/{x}/a/b/c",
-			},
-			path:     "/foo/a/b/c",
-			wantPath: "/{x}/a/b/c",
-			wantTsr:  false,
-			wantParams: Params{
-				{
-					Key:   "x",
-					Value: "foo",
-				},
-			},
-		},
-		{
-			name: "infix wildcard with tsr but skipped node does not match",
-			routes: []string{
-				"/foo/*{any}/",
-				"/{x}/a/b/x",
-			},
-			path:     "/foo/a/b/c",
-			wantPath: "/foo/*{any}/",
-			wantTsr:  true,
-			wantParams: Params{
-				{
-					Key:   "any",
-					Value: "a/b/c",
-				},
-			},
-		},
-		{
-			name: "infix wildcard with trailing slash and tsr add",
-			routes: []string{
-				"/foo/*{any}/",
-				"/foo/*{any}/abc",
-				"/foo/*{any}/bcd",
-			},
-			path:     "/foo/a/b/c/abd",
-			wantPath: "/foo/*{any}/",
-			wantTsr:  true,
-			wantParams: Params{
-				{
-					Key:   "any",
-					Value: "a/b/c/abd",
-				},
-			},
-		},
-		{
-			name: "infix wildcard with sub-node tsr add fallback",
-			routes: []string{
-				"/foo/*{any}/{a}/ddd/",
-				"/foo/*{any}/bbb/{d}/foo",
-			},
-			path:     "/foo/a/b/c/bbb/ddd",
-			wantPath: "/foo/*{any}/{a}/ddd/",
-			wantTsr:  true,
-			wantParams: Params{
-				{
-					Key:   "any",
-					Value: "a/b/c",
-				},
-				{
-					Key:   "a",
-					Value: "bbb",
-				},
-			},
-		},
-		{
-			name: "infix wildcard with sub-node tsr at depth 1 but direct match",
-			routes: []string{
-				"/foo/*{any}/c/bbb/",
-				"/foo/*{any}/bbb",
-			},
-			path:     "/foo/a/b/c/bbb",
-			wantPath: "/foo/*{any}/bbb",
-			wantTsr:  false,
-			wantParams: Params{
-				{
-					Key:   "any",
-					Value: "a/b/c",
-				},
-			},
-		},
-		{
-			name: "infix wildcard with sub-node tsr at depth 1 and 2 but direct match",
-			routes: []string{
-				"/foo/*{any}/b/c/bbb/",
-				"/foo/*{any}/c/bbb/",
-				"/foo/*{any}/bbb",
-			},
-			path:     "/foo/a/b/c/bbb",
-			wantPath: "/foo/*{any}/bbb",
-			wantTsr:  false,
-			wantParams: Params{
-				{
-					Key:   "any",
-					Value: "a/b/c",
-				},
-			},
-		},
-		{
-			name: "infix wildcard with sub-node tsr at depth 1 and 2 but fallback first tsr",
-			routes: []string{
-				"/foo/*{any}/b/c/bbb/",
-				"/foo/*{any}/c/bbb/",
-				"/foo/*{any}/bbx",
-			},
-			path:     "/foo/a/b/c/bbb",
-			wantPath: "/foo/*{any}/b/c/bbb/",
-			wantTsr:  true,
-			wantParams: Params{
-				{
-					Key:   "any",
-					Value: "a",
-				},
-			},
-		},
-		{
-			name: "infix wildcard with sub-node tsr at depth 1 and 2 but fallback first tsr",
-			routes: []string{
-				"/foo/*{any}/",
-				"/foo/*{any}/b/c/bbb/",
-				"/foo/*{any}/c/bbb/",
-				"/foo/*{any}/bbx",
-			},
-			path:     "/foo/a/b/c/bbb",
-			wantPath: "/foo/*{any}/b/c/bbb/",
-			wantTsr:  true,
-			wantParams: Params{
-				{
-					Key:   "any",
-					Value: "a",
-				},
-			},
-		},
-		{
-			name: "infix wildcard with depth 0 tsr and sub-node tsr at depth 1 fallback first tsr",
-			routes: []string{
-				"/foo/a/b/c/bbb/",
-				"/foo/*{any}/c/bbb/",
-				"/foo/*{any}/bbx",
-			},
-			path:     "/foo/a/b/c/bbb",
-			wantPath: "/foo/a/b/c/bbb/",
-			wantTsr:  true,
-		},
-		{
-			name: "infix wildcard with depth 0 tsr and sub-node tsr at depth 1 fallback first tsr",
-			routes: []string{
-				"/foo/{first}/b/c/bbb/",
-				"/foo/*{any}/c/bbb/",
-				"/foo/*{any}/bbx",
-			},
-			path:     "/foo/a/b/c/bbb",
-			wantPath: "/foo/{first}/b/c/bbb/",
-			wantTsr:  true,
-			wantParams: Params{
-				{
-					Key:   "first",
-					Value: "a",
-				},
-			},
-		},
-		{
-			name: "multi infix wildcard with sub-node tsr at depth 1 but direct match",
-			routes: []string{
-				"/foo/*{any1}/b/c/*{any2}/d/",
-				"/foo/*{any1}/c/*{any2}/d",
-			},
-			path:     "/foo/a/b/c/x/y/z/d",
-			wantPath: "/foo/*{any1}/c/*{any2}/d",
-			wantTsr:  false,
-			wantParams: Params{
-				{
-					Key:   "any1",
-					Value: "a/b",
-				},
-				{
-					Key:   "any2",
-					Value: "x/y/z",
-				},
-			},
-		},
-		{
-			name: "multi infix wildcard with sub-node tsr at depth 1 and fallback first",
-			routes: []string{
-				"/foo/*{any1}/b/c/*{any2}/d/",
-				"/foo/*{any1}/c/*{any2}/ff",
-			},
-			path:     "/foo/a/b/c/x/y/z/d",
-			wantPath: "/foo/*{any1}/b/c/*{any2}/d/",
-			wantTsr:  true,
-			wantParams: Params{
-				{
-					Key:   "any1",
-					Value: "a",
-				},
-				{
-					Key:   "any2",
-					Value: "x/y/z",
-				},
-			},
-		},
-	}
-
-	for _, tc := range cases {
-		t.Run(tc.name, func(t *testing.T) {
-			f := New()
-			tree := f.Tree()
-			for _, rte := range tc.routes {
-				require.NoError(t, onlyError(tree.Handle(http.MethodGet, rte, emptyHandler)))
-			}
-			nds := *tree.nodes.Load()
-			c := newTestContextTree(tree)
-			n, tsr := tree.lookup(nds[0].children[0].Load(), tc.path, c, false)
-			require.NotNil(t, n)
-			assert.Equal(t, tc.wantPath, n.route.path)
-			assert.Equal(t, tc.wantTsr, tsr)
-			c.tsr = tsr
-			assert.Equal(t, tc.wantParams, slices.Collect(c.Params()))
-
-			fmt.Println(n)
-			fmt.Println("nodes:", nds[0])
-		})
-	}
-
 }

--- a/fox_test.go
+++ b/fox_test.go
@@ -1421,6 +1421,32 @@ func TestInfixWildcard(t *testing.T) {
 			},
 		},
 		{
+			name:     "simple infix wildcard",
+			routes:   []string{"/foo/*{args}/bar"},
+			path:     "/foo/a/bar",
+			wantPath: "/foo/*{args}/bar",
+			wantTsr:  false,
+			wantParams: Params{
+				{
+					Key:   "args",
+					Value: "a",
+				},
+			},
+		},
+		{
+			name:     "static with infix wildcard child",
+			routes:   []string{"/foo/", "/foo/*{args}/baz"},
+			path:     "/foo/bar/baz",
+			wantPath: "/foo/*{args}/baz",
+			wantTsr:  false,
+			wantParams: Params{
+				{
+					Key:   "args",
+					Value: "bar",
+				},
+			},
+		},
+		{
 			name:     "simple infix wildcard with route char",
 			routes:   []string{"/foo/*{args}/bar"},
 			path:     "/foo/*{args}/bar",
@@ -2103,8 +2129,6 @@ func TestInfixWildcard(t *testing.T) {
 			assert.Equal(t, tc.wantTsr, tsr)
 			c.tsr = tsr
 			assert.Equal(t, tc.wantParams, slices.Collect(c.Params()))
-
-			fmt.Println(n)
 		})
 	}
 

--- a/fox_test.go
+++ b/fox_test.go
@@ -2803,6 +2803,18 @@ func TestParseRoute(t *testing.T) {
 			wantN:   0,
 		},
 		{
+			name:    "empty infix catch all",
+			path:    "/foo/bar/*{}/baz",
+			wantErr: ErrInvalidRoute,
+			wantN:   0,
+		},
+		{
+			name:    "empty ending catch all",
+			path:    "/foo/bar/baz/*{}",
+			wantErr: ErrInvalidRoute,
+			wantN:   0,
+		},
+		{
 			name:    "unexpected character in param",
 			path:    "/foo/{{bar}",
 			wantErr: ErrInvalidRoute,

--- a/iter.go
+++ b/iter.go
@@ -95,7 +95,7 @@ func (it Iter) Routes(methods iter.Seq[string], path string) iter.Seq2[string, *
 				continue
 			}
 
-			n, tsr := it.t.lookup(nds[index], path, c, true)
+			n, tsr := it.t.lookup(nds[index].children[0].Load(), path, c, true)
 			if n != nil && !tsr && n.route.path == path {
 				if !yield(method, n.route) {
 					return
@@ -128,7 +128,7 @@ func (it Iter) Reverse(methods iter.Seq[string], path string) iter.Seq2[string, 
 				continue
 			}
 
-			n, tsr := it.t.lookup(nds[index], path, c, true)
+			n, tsr := it.t.lookup(nds[index].children[0].Load(), path, c, true)
 			if n != nil && (!tsr || n.route.redirectTrailingSlash || n.route.ignoreTrailingSlash) {
 				if !yield(method, n.route) {
 					return

--- a/node.go
+++ b/node.go
@@ -238,16 +238,6 @@ type skippedNode struct {
 	childIndex int
 }
 
-func appendCatchAll(path, catchAllKey string) string {
-	if catchAllKey != "" {
-		suffix := "*{" + catchAllKey + "}"
-		if !strings.HasSuffix(path, suffix) {
-			return path + suffix
-		}
-	}
-	return path
-}
-
 // param represents a parsed parameter and its end position in the path.
 type param struct {
 	key string

--- a/node.go
+++ b/node.go
@@ -78,10 +78,6 @@ func (n *node) isLeaf() bool {
 	return n.route != nil
 }
 
-func (n *node) isCatchAll() bool {
-	return n.wildcardChildIndex >= 0
-}
-
 func (n *node) hasWildcard() bool {
 	return len(n.params) > 0
 }
@@ -191,26 +187,14 @@ func (n *node) string(space int) string {
 		sb.WriteString(" [paramIdx=")
 		sb.WriteString(strconv.Itoa(n.paramChildIndex))
 		sb.WriteByte(']')
-		if n.hasWildcard() {
-			sb.WriteString(" [")
-			for i, param := range n.params {
-				if i > 0 {
-					sb.WriteByte(',')
-				}
-				sb.WriteString(param.key)
-				sb.WriteString(" (")
-				sb.WriteString(strconv.Itoa(param.end))
-				sb.WriteString(")")
-			}
-			sb.WriteString("]")
-		}
-
 	}
 
-	// TODO we have to revise that
-	if n.isCatchAll() {
-		sb.WriteString(" [catchAll]")
+	if n.wildcardChildIndex >= 0 {
+		sb.WriteString(" [wildcardIdx=")
+		sb.WriteString(strconv.Itoa(n.wildcardChildIndex))
+		sb.WriteByte(']')
 	}
+
 	if n.isLeaf() {
 		sb.WriteString(" [leaf=")
 		sb.WriteString(n.route.path)
@@ -220,7 +204,7 @@ func (n *node) string(space int) string {
 		sb.WriteString(" [")
 		for i, param := range n.params {
 			if i > 0 {
-				sb.WriteByte(',')
+				sb.WriteString(", ")
 			}
 			sb.WriteString(param.key)
 			sb.WriteString(" (")

--- a/node.go
+++ b/node.go
@@ -18,11 +18,8 @@ type node struct {
 	route *Route
 
 	// key represent a segment of a route which share a common prefix with it parent.
+	// Once assigned, key is immutable.
 	key string
-
-	// Catch all key registered to retrieve this node parameter.
-	// Once assigned, catchAllKey is immutable.
-	catchAllKey string
 
 	// First char of each outgoing edges from this node sorted in ascending order.
 	// Once assigned, this is a read only slice. It allows to lazily traverse the
@@ -37,37 +34,43 @@ type node struct {
 	params []param
 
 	// The index of a paramChild if any, -1 if none (per rules, only one paramChildren is allowed).
-	paramChildIndex int
+	// Once assigned, paramChildIndex is immutable.
+	paramChildIndex int // TODO uint32
+	// The index of a wildcardChild if any, -1 if none (per rules, only one wildcardChild is allowed).
+	// Once assigned, wildcardChildIndex is immutable.
+	wildcardChildIndex int
 }
 
-func newNode(key string, route *Route, children []*node, catchAllKey string) *node {
+func newNode(key string, route *Route, children []*node) *node {
 	slices.SortFunc(children, func(a, b *node) int {
 		return cmp.Compare(a.key, b.key)
 	})
 	nds := make([]atomic.Pointer[node], len(children))
 	childKeys := make([]byte, len(children))
-	childIndex := -1
+	paramChildIndex := -1
+	wildcardChildIndex := -1
 	for i := range children {
 		assertNotNil(children[i])
 		childKeys[i] = children[i].key[0]
 		nds[i].Store(children[i])
 		if strings.HasPrefix(children[i].key, "{") {
-			childIndex = i
+			paramChildIndex = i
+		} else if strings.HasPrefix(children[i].key, "*") {
+			wildcardChildIndex = i
 		}
 	}
-
-	return newNodeFromRef(key, route, nds, childKeys, catchAllKey, childIndex)
+	return newNodeFromRef(key, route, nds, childKeys, paramChildIndex, wildcardChildIndex)
 }
 
-func newNodeFromRef(key string, route *Route, children []atomic.Pointer[node], childKeys []byte, catchAllKey string, childIndex int) *node {
+func newNodeFromRef(key string, route *Route, children []atomic.Pointer[node], childKeys []byte, paramChildIndex, wildcardChildIndex int) *node {
 	return &node{
-		key:             key,
-		childKeys:       childKeys,
-		children:        children,
-		route:           route,
-		catchAllKey:     catchAllKey,
-		paramChildIndex: childIndex,
-		params:          parseWildcard(key),
+		key:                key,
+		childKeys:          childKeys,
+		children:           children,
+		route:              route,
+		paramChildIndex:    paramChildIndex,
+		wildcardChildIndex: wildcardChildIndex,
+		params:             parseWildcard(key),
 	}
 }
 
@@ -76,7 +79,7 @@ func (n *node) isLeaf() bool {
 }
 
 func (n *node) isCatchAll() bool {
-	return n.catchAllKey != ""
+	return n.wildcardChildIndex >= 0
 }
 
 func (n *node) hasWildcard() bool {
@@ -204,6 +207,7 @@ func (n *node) string(space int) string {
 
 	}
 
+	// TODO we have to revise that
 	if n.isCatchAll() {
 		sb.WriteString(" [catchAll]")
 	}
@@ -244,10 +248,10 @@ func (n *skippedNodes) pop() skippedNode {
 }
 
 type skippedNode struct {
-	n         *node
-	pathIndex int
-	paramCnt  uint32
-	seen      bool
+	n          *node
+	pathIndex  int
+	paramCnt   uint32
+	childIndex int
 }
 
 func appendCatchAll(path, catchAllKey string) string {
@@ -263,8 +267,10 @@ func appendCatchAll(path, catchAllKey string) string {
 // param represents a parsed parameter and its end position in the path.
 type param struct {
 	key string
-	end int // -1 if end with {a}, else pos of the next char
-	// catchAll bool
+	// -1 if end with {a}, else pos of the next char. Note that since infix wildcard are always followed
+	// by a static segment, pos should be always > 0
+	end      int
+	catchAll bool
 }
 
 func parseWildcard(segment string) []param {
@@ -289,28 +295,28 @@ func parseWildcard(segment string) []param {
 				state = stateDefault
 			}
 			i++
-			//case stateCatchAll:
-			//if segment[i] == '}' {
-			//	end := -1
-			//	if len(segment[i+1:]) > 0 {
-			//		end = i + 1
-			//	}
-			//	params = append(params, param{
-			//		key:      segment[start:i],
-			//		end:      end,
-			//		catchAll: true,
-			//	})
-			//	start = 0
-			//	state = stateDefault
-			//}
-			//i++
+		case stateCatchAll:
+			if segment[i] == '}' {
+				end := -1
+				if len(segment[i+1:]) > 0 {
+					end = i + 1
+				}
+				params = append(params, param{
+					key:      segment[start:i],
+					end:      end,
+					catchAll: true,
+				})
+				start = 0
+				state = stateDefault
+			}
+			i++
 		default:
-			//	if segment[i] == '*' {
-			//	state = stateCatchAll
-			//	i += 2
-			//	start = i
-			//	continue
-			//}
+			if segment[i] == '*' {
+				state = stateCatchAll
+				i += 2
+				start = i
+				continue
+			}
 
 			if segment[i] == '{' {
 				state = stateParam

--- a/options.go
+++ b/options.go
@@ -233,13 +233,6 @@ func WithAnnotations(annotations ...Annotation) PathOption {
 	})
 }
 
-// WithAnnotation attaches a single key-value annotation to a route. See also [WithAnnotations] and [Annotation] for more details.
-func WithAnnotation(key string, value any) PathOption {
-	return pathOptionFunc(func(route *Route) {
-		route.annots = append(route.annots, Annotation{key, value})
-	})
-}
-
 // DefaultOptions configure the router to use the Recovery middleware for the RouteHandler scope, the Logger middleware
 // for AllHandlers scope and enable automatic OPTIONS response. Note that DefaultOptions push the Recovery and Logger middleware
 // respectively to the first and second position of the middleware chains.

--- a/route.go
+++ b/route.go
@@ -5,9 +5,6 @@ import (
 	"strings"
 )
 
-// Annotations is a collection of Annotation key-value pairs that can be attached to routes.
-type Annotations []Annotation
-
 // Annotation represents a single key-value pair that provides metadata for a route.
 // Annotations are typically used to store information that can be leveraged by middleware, handlers, or external
 // libraries to modify or customize route behavior.
@@ -25,7 +22,7 @@ type Route struct {
 	hall                  HandlerFunc
 	path                  string
 	mws                   []middleware
-	annots                Annotations
+	annots                []Annotation
 	redirectTrailingSlash bool
 	ignoreTrailingSlash   bool
 }

--- a/tree.go
+++ b/tree.go
@@ -528,6 +528,7 @@ func (t *Tree) remove(method, path string) bool {
 const (
 	slashDelim   = '/'
 	bracketDelim = '{'
+	starDelim    = '*'
 )
 
 func (t *Tree) lookup(target *node, path string, c *cTx, lazy bool) (n *node, tsr bool) {
@@ -550,8 +551,8 @@ Walk:
 				break
 			}
 
-			if current.key[i] != path[charsMatched] || path[charsMatched] == bracketDelim || path[charsMatched] == '*' {
-				if current.key[i] == '{' {
+			if current.key[i] != path[charsMatched] || path[charsMatched] == bracketDelim || path[charsMatched] == starDelim {
+				if current.key[i] == bracketDelim {
 					startPath := charsMatched
 					idx := strings.IndexByte(path[charsMatched:], slashDelim)
 					if idx > 0 {
@@ -584,7 +585,7 @@ Walk:
 					continue
 				}
 
-				if current.key[i] == '*' {
+				if current.key[i] == starDelim {
 					//                | current.params[paramKeyCnt].end (10)
 					// key: foo/*{bar}/                                      => 10 - 5 = 5 => i+=idx set i to '/'
 					//          | charsMatchedInNodeFound (5)

--- a/tree.go
+++ b/tree.go
@@ -531,11 +531,7 @@ const (
 	bracketDelim = '{'
 )
 
-func (t *Tree) lookup(rootNode *node, path string, c *cTx, lazy bool) (n *node, tsr bool) {
-	/*	if len(rootNode.children) == 0 {
-		return nil, false
-	}*/
-
+func (t *Tree) lookup(target *node, path string, c *cTx, lazy bool) (n *node, tsr bool) {
 	var (
 		charsMatched            int
 		charsMatchedInNodeFound int
@@ -544,8 +540,7 @@ func (t *Tree) lookup(rootNode *node, path string, c *cTx, lazy bool) (n *node, 
 		parent                  *node
 	)
 
-	// current := rootNode.children[0].Load()
-	current := rootNode
+	current := target
 	*c.skipNds = (*c.skipNds)[:0]
 
 Walk:
@@ -556,10 +551,10 @@ Walk:
 				break
 			}
 
-			x := string(current.key[i])
-			y := string(path[charsMatched])
-			_ = x
-			_ = y
+			/*			x := string(current.key[i])
+						y := string(path[charsMatched])
+						_ = x
+						_ = y*/
 
 			if current.key[i] != path[charsMatched] || path[charsMatched] == bracketDelim || path[charsMatched] == '*' {
 				if current.key[i] == '{' {
@@ -642,16 +637,16 @@ Walk:
 
 					newCtx := t.ctx.Get().(*cTx)
 					startPath := charsMatched
-					y := path[charsMatched:]
-					_ = y
+					/*					y := path[charsMatched:]
+										_ = y*/
 					for {
 						idx := strings.IndexByte(path[charsMatched:], slashDelim)
 						// idx >= 0, we have a next segment with at least one char
 						if idx > 0 {
 							*newCtx.params = (*newCtx.params)[:0]
 							charsMatched += idx
-							x := path[charsMatched:]
-							_ = x
+							/*							x := path[charsMatched:]
+														_ = x*/
 							newNode, newTsr := t.lookup(interNode, path[charsMatched:], newCtx, false)
 							if newNode != nil {
 								t.np.Put(interNode)
@@ -689,8 +684,8 @@ Walk:
 						// char matched need to be re ajusted with probabley len(path
 						charsMatched += len(path[charsMatched:])
 						// and this point len(path) == charsMatched
-						ctrl := len(path) == charsMatched
-						_ = ctrl
+						/*						ctrl := len(path) == charsMatched
+												_ = ctrl*/
 
 						break Walk
 					}

--- a/tree.go
+++ b/tree.go
@@ -530,8 +530,6 @@ const (
 	bracketDelim = '{'
 )
 
-var depth int
-
 func (t *Tree) lookup(target *node, path string, c *cTx, lazy bool) (n *node, tsr bool) {
 	var (
 		charsMatched            int
@@ -679,7 +677,6 @@ Walk:
 						// there is no tsr opportunity, and skipped nodes > 0, we will truncate the params anyway.
 						if !lazy {
 							*c.params = append(*c.params, Param{Key: current.params[paramKeyCnt].key, Value: path[startPath:]})
-							paramCnt++
 						}
 
 						// We are also in an ending catch all, and this is the most specific path
@@ -688,9 +685,6 @@ Walk:
 						}
 
 						charsMatched += len(path[charsMatched:])
-						// and this point len(path) == charsMatched
-						ctrl := len(path) == charsMatched
-						_ = ctrl
 
 						break Walk
 					}

--- a/tree.go
+++ b/tree.go
@@ -737,7 +737,7 @@ Walk:
 				break
 			}
 
-			// Here we have a next static segment and possibly wildcard children, so we save them for late evaluation if needed.
+			// Here we have a next static segment and possibly wildcard children, so we save them for later evaluation if needed.
 			if current.wildcardChildIndex >= 0 {
 				*c.skipNds = append(*c.skipNds, skippedNode{current, charsMatched, paramCnt, current.wildcardChildIndex})
 			}

--- a/tree.go
+++ b/tree.go
@@ -597,20 +597,14 @@ Walk:
 					idx := current.params[paramKeyCnt].end - charsMatchedInNodeFound
 					var interNode *node
 					if idx >= 0 {
-						// -1 since on the next incrementation, if any, 'i' are going to be incremented
-						// i += idx - 1
-						charsMatchedInNodeFound += idx
-
 						interNode = t.np.Get().(*node)
 						interNode.params = interNode.params[:0]
-						interNode = &node{
-							route:              current.route,
-							key:                current.key[current.params[paramKeyCnt].end:],
-							childKeys:          current.childKeys,
-							children:           current.children,
-							paramChildIndex:    current.paramChildIndex,
-							wildcardChildIndex: current.wildcardChildIndex,
-						}
+						interNode.route = current.route
+						interNode.key = current.key[current.params[paramKeyCnt].end:]
+						interNode.childKeys = current.childKeys
+						interNode.children = current.children
+						interNode.paramChildIndex = current.paramChildIndex
+						interNode.wildcardChildIndex = current.wildcardChildIndex
 						for _, ps := range current.params[paramKeyCnt+1:] { // paramKeyCnt+1 is safe since we have at least the current infix wildcard in params
 							interNode.params = append(interNode.params, param{
 								key: ps.key,
@@ -621,11 +615,11 @@ Walk:
 							})
 						}
 
+						charsMatchedInNodeFound += idx
+
 					} else if len(current.children) > 0 {
 						// Infix catch all
 						interNode = current.get(0)
-						// -1 since on the next incrementation, if any, 'i' are going to be incremented
-						// i += len(current.key[charsMatchedInNodeFound:]) - 1
 						charsMatchedInNodeFound += len(current.key[charsMatchedInNodeFound:])
 					} else {
 						// We are in an ending catch all node with no child, so it's a direct match


### PR DESCRIPTION
### Introduction

This pull request introduces support for **infix catch-all wildcard** parameters, enhancing the routing flexibility. Developers can now define routes with catch-all parameters (`*{param}`) not only at the end but also in the middle of the route path. This allows for more dynamic and versatile URL matching patterns, catering to a wider range of application requirements.

### Background and Motivation

Previously, the router supported:

- **Named Parameters**: `{param}` matching exactly one non-empty path segment.
- **Catch-All Parameters**: `*{param}` matching zero or more segments, but only at the **end** of a route path.

This limitation restricted the ability to define routes that require matching variable-length path segments within the middle of a URL. Infix catch-all parameters allow for more complex and descriptive routing patterns, such as `/*/track` (a feature needed for Wiztrack that was not supported by `gin`).

### Breaking Change

One subtle breaking change has been introduced: **catch-all wildcards no longer match empty segments**, including at the end of a route. All matches now have to be explicit. However, it's now possible to define routes such as `/path/` and `/path/*{any}` to reproduce the same empty match behavior (which was previously not allowed).

#### Handling Empty Segments

To match both routes with and without additional path segments, you can register two routes:

```go
// Matches the path with no additional segments
f.Handle("GET", "/path/", handlerForEmpty)

// Matches the path with one or more additional segments
f.Handle("GET", "/path/*{any}", handlerForCatchAll)
```

This explicit approach ensures that you only handle empty segments when you intend to.

#### Security Consideration

A common scenario is serving static content using a route like `/static/*{filepath}`. In many routers (e.g., standard `http.ServeMux`, Gin, Echo), this route matches empty segments by default, potentially allowing **directory listing**, of the base folder which can be a security concern.

By not matching empty segments with catch-all wildcards, we can at least prevents unintended directory listing.

#### Future Considerations

Serving static files and handling directory listings are common needs. In the future, we plan to introduce an API helper to simplify serving static content.

### Infix Wildcards

Catch-all wildcards can now be placed **anywhere** in the path, not just at the end.

**Example:**

```
Pattern: /assets/*{path}/thumbnail

- /assets/images/thumbnail           matches, {path} = "images"
- /assets/photos/2021/thumbnail      matches, {path} = "photos/2021"
- /assets//thumbnail                 does not match (empty {path} not matched)
```

They can also be followed or preceded by named parameters. For example, `/foo/*{bar}/{baz}` is valid and allows for flexible route definitions.

**Note:** Catch-all wildcards **cannot be consecutive**. For example, `/foo/*{any1}/*{any2}` is not allowed. Since catch-all wildcards match at least one segment, the above pattern is equivalent to `/foo/{param}/*{catchAll}`, which is allowed and more explicit about which segment matches each parameter.

---


### Differential Benchmark
```
goos: linux
goarch: amd64
pkg: github.com/tigerwill90/fox
cpu: Intel(R) Core(TM) i9-9900K CPU @ 3.60GHz
                    │   old.txt   │               new.txt                │
                    │   sec/op    │    sec/op     vs base                │
StaticAll-16          11.28µ ± 4%    12.14µ ± 6%   +7.63% (p=0.000 n=10)
GithubParamsAll-16    75.66n ± 2%    84.42n ± 3%  +11.58% (p=0.000 n=10)
OverlappingRoute-16   91.59n ± 1%    96.75n ± 2%   +5.63% (p=0.000 n=10)
StaticParallel-16     9.582n ± 5%   10.740n ± 2%  +12.09% (p=0.000 n=10)
CatchAll-16           31.39n ± 6%    35.53n ± 2%  +13.19% (p=0.000 n=10)
CatchAllParallel-16   5.973n ± 5%    5.737n ± 8%        ~ (p=0.289 n=10)
CloneWith-16          63.58n ± 2%    69.98n ± 1%  +10.07% (p=0.000 n=10)
geomean               70.82n         76.40n        +7.89%
```