### PR TITLE
Improve client ip resolver performance for edge-case

### DIFF
--- a/clientip/clientip_test.go
+++ b/clientip/clientip_test.go
@@ -218,7 +218,7 @@ func TestChain_ClientIP(t *testing.T) {
 	assert.ErrorIs(t, err, ErrSingleIPHeader)
 	assert.ErrorIs(t, err, ErrRemoteAddress)
 	assert.ErrorIs(t, err, ErrInvalidIpAddress)
-	assert.ErrorContains(t, err, "header \"Cf-Connecting-Ip\" not found")
+	assert.ErrorContains(t, err, "header not found")
 }
 
 func TestAddressesAndRangesToIPNets(t *testing.T) {
@@ -721,7 +721,7 @@ func Test_forwardedHeaderRFCDeviations(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			got := slices.Collect(ipAddrSeq(tt.args.headers, tt.args.headerName))
+			got := slices.Collect(ipAddrSeq(tt.args.headers[tt.args.headerName], tt.args.headerName))
 			assert.Equal(t, tt.want, got)
 		})
 	}

--- a/http_consts.go
+++ b/http_consts.go
@@ -51,7 +51,6 @@ const (
 	HeaderXForwardedProto     = "X-Forwarded-Proto"
 	HeaderXForwardedProtocol  = "X-Forwarded-Protocol"
 	HeaderXForwardedSsl       = "X-Forwarded-Ssl"
-	HeaderXRealIP             = "X-Real-Ip"
 	HeaderXUrlScheme          = "X-Url-Scheme"
 	HeaderXHTTPMethodOverride = "X-HTTP-Method-Override"
 	HeaderXRequestID          = "X-Request-Id"
@@ -92,6 +91,7 @@ const (
 	HeaderXAzureSocketIP       = "X-Azure-SocketIP"
 	HeaderXAppengineRemoteAddr = "X-Appengine-Remote-Addr"
 	HeaderFlyClientIP          = "Fly-Client-IP"
+	HeaderXRealIP              = "X-Real-Ip"
 )
 
 // nolint:gosec


### PR DESCRIPTION
### Description  
This PR introduces performance improvements to the `clientip` package.  Those changes focus to environments where the network configuration is unknown, making such cases more efficient to handle.  

#### Key Enhancements:  
1. **Reduced Allocations in `LeftmostNonPrivate` Resolver**  
   - Optimized to minimize memory allocations when neither the `X-Forwarded-For` nor `Forwarded` headers are present.  

2. **Improved `SingleIPHeader` Resolver**  
   - Now returns a precomputed error, improving efficiency in scenarios where multiple chained `SingleIPHeader` resolvers are used to identify the client IP.