### PR TITLE
Enforce Option Immutability for Router and Route

### DIFF
--- a/clientip/clientip.go
+++ b/clientip/clientip.go
@@ -35,8 +35,9 @@ var (
 // Avoid allocating those errors each time since it may happen a lot on adversary header or when using multiple single ip
 // header resolver in order to find the right match.
 var (
-	errLeftmostNonPrivate = fmt.Errorf("%w: unable to find a valid or non-private IP", ErrLeftmostNonPrivate)
-	errSingleIPHeader     = fmt.Errorf("%w: header not found", ErrSingleIPHeader)
+	errLeftmostNonPrivate  = fmt.Errorf("%w: unable to find a valid or non-private IP", ErrLeftmostNonPrivate)
+	errRightmostNonPrivate = fmt.Errorf("%w: unable to find a valid or non-private IP", ErrRightmostNonPrivate)
+	errSingleIPHeader      = fmt.Errorf("%w: header not found", ErrSingleIPHeader)
 )
 
 // TrustedIPRange returns a set of trusted IP ranges.
@@ -243,7 +244,7 @@ func (s RightmostNonPrivate) ClientIP(c fox.Context) (*net.IPAddr, error) {
 		}
 	}
 	// We failed to find any valid, non-private IP
-	return nil, fmt.Errorf("%w: unable to find a valid or non-private IP", ErrRightmostNonPrivate)
+	return nil, errRightmostNonPrivate
 }
 
 // RightmostTrustedCount derives the client IP from the valid IP address added by the first trusted reverse

--- a/clientip/options.go
+++ b/clientip/options.go
@@ -1,6 +1,8 @@
 package clientip
 
-import "net"
+import (
+	"net"
+)
 
 type config struct {
 	ipRanges []net.IPNet

--- a/fox.go
+++ b/fox.go
@@ -143,7 +143,7 @@ func New(opts ...GlobalOption) (*Router, error) {
 	r.maxParamKeyBytes = math.MaxUint16
 
 	for _, opt := range opts {
-		if err := opt.applyGlob(r); err != nil {
+		if err := opt.applyGlob(sealedOption{router: r}); err != nil {
 			return nil, err
 		}
 	}
@@ -421,7 +421,7 @@ func (fox *Router) newRoute(pattern string, handler HandlerFunc, opts ...RouteOp
 	}
 
 	for _, opt := range opts {
-		if err = opt.applyRoute(rte); err != nil {
+		if err = opt.applyRoute(sealedOption{route: rte}); err != nil {
 			return nil, 0, err
 		}
 	}

--- a/http_consts.go
+++ b/http_consts.go
@@ -58,6 +58,7 @@ const (
 	HeaderXRequestedWith      = "X-Requested-With"
 	HeaderServer              = "Server"
 	HeaderOrigin              = "Origin"
+	HeaderHost                = "Host"
 	HeaderCacheControl        = "Cache-Control"
 	HeaderConnection          = "Connection"
 	HeaderETag                = "ETag"


### PR DESCRIPTION
**Description:**  
This PR introduces a small improvement to enforce the immutability of `Router` and `Route` options by encapsulating their state within a private struct, `sealedOption`. This ensures that options cannot be mutated once they are applied, preventing unintended side effects and protecting the integrity of `Router` and `Route` configurations.

### Rationale:  
Without this protection, users could bypass immutability through type assertions, as shown in the following example:

```go
f, _ := fox.New()

// And later a user want to update the not found handler which would be a race.
opt := fox.WithNoRouteHandler(handler)
// Bypassing immutability via type assertion
applier := opt.(interface{ applyGlob(*fox.Router) error })
// Mutates the router state directly
applier.applyGlob(f) 
```

Such misuse allows for mutation outside the expected lifecycle, potentially leading to unpredictable behavior or runtime bugs. The `sealedOption` struct ensures that external packages cannot implement the `Option`, `GlobalOption` and `RouteOption` and thus cannot mutate the internal state of the router or route.