### PR TITLE
Returns the route on deletion

### DIFF
--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -9,7 +9,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        go: [ '>=1.21' ]
+        go: [ '>=1.23' ]
     steps:
       - name: Set up Go
         uses: actions/setup-go@v5
@@ -36,7 +36,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        go: [ '>=1.21' ]
+        go: [ '>=1.23' ]
     steps:
       - name: Set up Go
         uses: actions/setup-go@v5

--- a/README.md
+++ b/README.md
@@ -343,7 +343,7 @@ func Action(c fox.Context) {
 			_ = c.String(http.StatusOK, text)
 		})
 	case "delete":
-		err = c.Fox().Delete(method, path)
+		_, err = c.Fox().Delete(method, path)
 	default:
 		http.Error(c.Writer(), fmt.Sprintf("action %q is not allowed", action), http.StatusBadRequest)
 		return
@@ -392,7 +392,7 @@ if err := f.Updates(func(txn *fox.Txn) error {
 	// It means that writing on the current transaction while iterating is allowed, but the mutation will not be
 	// observed in the result returned by Prefix (or any other iterator).
 	for method, route := range it.Prefix(it.Methods(), "tmp.exemple.com/") {
-		if err := txn.Delete(method, route.Pattern()); err != nil {
+		if _, err := txn.Delete(method, route.Pattern()); err != nil {
 			return err
 		}
 	}
@@ -419,7 +419,7 @@ it := txn.Iter()
 // It means that writing on the current transaction while iterating is allowed, but the mutation will not be
 // observed in the result returned by Prefix (or any other iterator).
 for method, route := range it.Prefix(it.Methods(), "tmp.exemple.com/") {
-	if err := txn.Delete(method, route.Pattern()); err != nil {
+	if _, err := txn.Delete(method, route.Pattern()); err != nil {
 		log.Printf("error deleting route: %s", err)
 		return
 	}

--- a/context.go
+++ b/context.go
@@ -59,6 +59,8 @@ type Context interface {
 	Params() iter.Seq[Param]
 	// Param retrieve a matching wildcard parameter by name.
 	Param(name string) string
+	// Method returns the request method.
+	Method() string
 	// Path returns the request URL path.
 	Path() string
 	// Host returns the request host.
@@ -234,6 +236,11 @@ func (c *cTx) Param(name string) string {
 		}
 	}
 	return ""
+}
+
+// Method returns the request method.
+func (c *cTx) Method() string {
+	return c.req.Method
 }
 
 // Path returns the request URL path.

--- a/fox.go
+++ b/fox.go
@@ -157,10 +157,8 @@ func New(opts ...GlobalOption) (*Router, error) {
 	return r, nil
 }
 
-// MustHandle registers a new handler for the given method and route pattern. On success, it returns the newly registered [Route]
-// This function is a convenience wrapper for the [Router.Handle] function and panics on error. It's perfectly safe to
-// add a new handler while the router is serving requests. This function is safe for concurrent use by multiple goroutines.
-// To override an existing route, use [Router.Update].
+// MustHandle registers a new route for the given method and pattern. On success, it returns the newly registered [Route].
+// This function is a convenience wrapper for the [Router.Handle] function and panics on error.
 func (fox *Router) MustHandle(method, pattern string, handler HandlerFunc, opts ...RouteOption) *Route {
 	rte, err := fox.Handle(method, pattern, handler, opts...)
 	if err != nil {
@@ -169,7 +167,7 @@ func (fox *Router) MustHandle(method, pattern string, handler HandlerFunc, opts 
 	return rte
 }
 
-// Handle registers a new handler for the given method and route pattern. On success, it returns the newly registered [Route].
+// Handle registers a new route for the given method and pattern. On success, it returns the newly registered [Route].
 // If an error occurs, it returns one of the following:
 //   - [ErrRouteExist]: If the route is already registered.
 //   - [ErrRouteConflict]: If the route conflicts with another.
@@ -189,7 +187,7 @@ func (fox *Router) Handle(method, pattern string, handler HandlerFunc, opts ...R
 	return rte, nil
 }
 
-// HandleRoute registers a new route for the given method. If an error occurs, it returns one of the following:
+// HandleRoute registers a new [Route] for the given method. If an error occurs, it returns one of the following:
 //   - [ErrRouteExist]: If the route is already registered.
 //   - [ErrRouteConflict]: If the route conflicts with another.
 //   - [ErrInvalidRoute]: If the provided method is invalid or the route is missing.
@@ -207,7 +205,7 @@ func (fox *Router) HandleRoute(method string, route *Route) error {
 	return nil
 }
 
-// Update override an existing handler for the given method and route pattern. On success, it returns the newly registered [Route].
+// Update override an existing route for the given method and pattern. On success, it returns the newly registered [Route].
 // If an error occurs, it returns one of the following:
 //   - [ErrRouteNotFound]: If the route does not exist.
 //   - [ErrInvalidRoute]: If the provided method or pattern is invalid.
@@ -228,7 +226,7 @@ func (fox *Router) Update(method, pattern string, handler HandlerFunc, opts ...R
 	return rte, nil
 }
 
-// UpdateRoute override an existing route for the given method and new route.
+// UpdateRoute override an existing [Route] for the given method and new [Route].
 // If an error occurs, it returns one of the following:
 //   - [ErrRouteNotFound]: If the route does not exist.
 //   - [ErrInvalidRoute]: If the provided method is invalid or the route is missing.
@@ -246,20 +244,21 @@ func (fox *Router) UpdateRoute(method string, route *Route) error {
 	return nil
 }
 
-// Delete deletes an existing handler for the given method and route pattern. If an error occurs, it returns one of the following:
+// Delete deletes an existing route for the given method and pattern. On success, it returns the deleted [Route].
 //   - [ErrRouteNotFound]: If the route does not exist.
 //   - [ErrInvalidRoute]: If the provided method or pattern is invalid.
 //
 // It's safe to delete a handler while the router is serving requests. This function is safe for concurrent use by
 // multiple goroutine.
-func (fox *Router) Delete(method, pattern string) error {
+func (fox *Router) Delete(method, pattern string) (*Route, error) {
 	txn := fox.txnWith(true, false)
 	defer txn.Abort()
-	if err := txn.Delete(method, pattern); err != nil {
-		return err
+	route, err := txn.Delete(method, pattern)
+	if err != nil {
+		return nil, err
 	}
 	txn.Commit()
-	return nil
+	return route, nil
 }
 
 // Has allows to check if the given method and route pattern exactly match a registered route. This function is safe for

--- a/fox_test.go
+++ b/fox_test.go
@@ -4646,6 +4646,26 @@ func TestTree_DeleteRoot(t *testing.T) {
 	assert.Equal(t, 4, len(tree.root))
 }
 
+func TestRouter_DeleteError(t *testing.T) {
+	f, _ := New()
+	require.NoError(t, onlyError(f.Handle(http.MethodOptions, "/foo/bar", emptyHandler)))
+	t.Run("delete with empty method", func(t *testing.T) {
+		r, err := f.Delete("", "/foo/bar")
+		assert.ErrorIs(t, err, ErrInvalidRoute)
+		assert.Nil(t, r)
+	})
+	t.Run("delete invalid route", func(t *testing.T) {
+		r, err := f.Delete(http.MethodGet, "/{")
+		assert.ErrorIs(t, err, ErrInvalidRoute)
+		assert.Nil(t, r)
+	})
+	t.Run("route does not exist", func(t *testing.T) {
+		r, err := f.Delete(http.MethodGet, "/foo/bar/")
+		assert.ErrorIs(t, err, ErrRouteNotFound)
+		assert.Nil(t, r)
+	})
+}
+
 func TestRouter_UpdatesError(t *testing.T) {
 	f, _ := New()
 	wantErr := errors.New("error")

--- a/fox_test.go
+++ b/fox_test.go
@@ -4648,7 +4648,7 @@ func TestTree_DeleteRoot(t *testing.T) {
 
 func TestRouter_DeleteError(t *testing.T) {
 	f, _ := New()
-	require.NoError(t, onlyError(f.Handle(http.MethodOptions, "/foo/bar", emptyHandler)))
+	require.NoError(t, onlyError(f.Handle(http.MethodGet, "/foo/bar", emptyHandler)))
 	t.Run("delete with empty method", func(t *testing.T) {
 		r, err := f.Delete("", "/foo/bar")
 		assert.ErrorIs(t, err, ErrInvalidRoute)
@@ -4661,6 +4661,11 @@ func TestRouter_DeleteError(t *testing.T) {
 	})
 	t.Run("route does not exist", func(t *testing.T) {
 		r, err := f.Delete(http.MethodGet, "/foo/bar/")
+		assert.ErrorIs(t, err, ErrRouteNotFound)
+		assert.Nil(t, r)
+	})
+	t.Run("method does not exist", func(t *testing.T) {
+		r, err := f.Delete(http.MethodPost, "/foo/bar")
 		assert.ErrorIs(t, err, ErrRouteNotFound)
 		assert.Nil(t, r)
 	})

--- a/fox_test.go
+++ b/fox_test.go
@@ -4665,7 +4665,7 @@ func TestRouter_DeleteError(t *testing.T) {
 		assert.Nil(t, r)
 	})
 	t.Run("method does not exist", func(t *testing.T) {
-		r, err := f.Delete(http.MethodPost, "/foo/bar")
+		r, err := f.Delete(http.MethodTrace, "/foo/bar")
 		assert.ErrorIs(t, err, ErrRouteNotFound)
 		assert.Nil(t, r)
 	})

--- a/internal/slogpretty/handler.go
+++ b/internal/slogpretty/handler.go
@@ -197,23 +197,21 @@ func appendAttr(level slog.Level, buf []byte, attr slog.Attr) []byte {
 	buf = append(buf, ansi.NormalIntensity...)
 
 	var addWhitespace bool
-	if _, isErr := attr.Value.Any().(error); isErr {
+	switch attr.Key {
+	case "method":
+		buf = append(buf, ansi.BgBlue...)
+		addWhitespace = true
+	case "status":
+		buf = append(buf, levelColor(level)...)
+		addWhitespace = true
+	case "location":
+		buf = append(buf, ansi.FgYellow...)
+	case "latency":
+		buf = append(buf, latencyColor(attr.Value.Duration())...)
+	case "error":
 		buf = append(buf, ansi.FgRed...)
-	} else {
-		switch attr.Key {
-		case "method":
-			buf = append(buf, ansi.BgBlue...)
-			addWhitespace = true
-		case "status":
-			buf = append(buf, levelColor(level)...)
-			addWhitespace = true
-		case "location":
-			buf = append(buf, ansi.FgYellow...)
-		case "latency":
-			buf = append(buf, latencyColor(attr.Value.Duration())...)
-		default:
-			buf = append(buf, ansi.FgCyan...)
-		}
+	default:
+		buf = append(buf, ansi.FgCyan...)
 	}
 
 	if addWhitespace {

--- a/logger.go
+++ b/logger.go
@@ -44,9 +44,9 @@ func LoggerWithHandler(handler slog.Handler) MiddlewareFunc {
 					lvl,
 					ipStr,
 					slog.Int("status", c.Writer().Status()),
-					slog.String("method", req.Method),
+					slog.String("method", c.Method()),
 					slog.String("host", c.Host()),
-					slog.String("path", c.Request().URL.String()),
+					slog.String("path", c.Path()),
 					slog.Duration("latency", roundLatency(latency)),
 				)
 			} else {
@@ -55,9 +55,9 @@ func LoggerWithHandler(handler slog.Handler) MiddlewareFunc {
 					lvl,
 					ipStr,
 					slog.Int("status", c.Writer().Status()),
-					slog.String("method", req.Method),
+					slog.String("method", c.Method()),
 					slog.String("host", c.Host()),
-					slog.String("path", c.Request().URL.String()),
+					slog.String("path", c.Path()),
 					slog.Duration("latency", roundLatency(latency)),
 					slog.String("location", location),
 				)

--- a/node.go
+++ b/node.go
@@ -645,7 +645,9 @@ func newNode(key string, route *Route, children []*node) *node {
 		childKeys[i] = children[i].key[0]
 		if strings.HasPrefix(children[i].key, "{") {
 			paramChildIndex = i
-		} else if strings.HasPrefix(children[i].key, "*") {
+			continue
+		}
+		if strings.HasPrefix(children[i].key, "*") {
 			wildcardChildIndex = i
 		}
 	}


### PR DESCRIPTION
This PR improve the `Txn.Delete` and `Router.Delete` api by returning the deleted `Route` on success.