### PR TITLE
Fix potential panic with TSR feature

### DIFF
--- a/fox_test.go
+++ b/fox_test.go
@@ -4075,6 +4075,11 @@ func TestTree_LookupTsr(t *testing.T) {
 			wantPath: "/users",
 		},
 		{
+			name:  "match mid edge in child node with parent not leaf",
+			paths: []string{"/test/x", "/tests/"},
+			key:   "/test/",
+		},
+		{
 			name:  "match mid edge in child node with invalid remaining prefix",
 			paths: []string{"/users/{id}"},
 			key:   "/users/",

--- a/go.mod
+++ b/go.mod
@@ -5,7 +5,7 @@ go 1.23.0
 require (
 	github.com/google/gofuzz v1.2.0
 	github.com/stretchr/testify v1.10.0
-	golang.org/x/sys v0.29.0
+	golang.org/x/sys v0.30.0
 )
 
 require (

--- a/go.sum
+++ b/go.sum
@@ -19,8 +19,8 @@ github.com/rogpeppe/go-internal v1.8.0 h1:FCbCCtXNOY3UtUuHUYaghJg4y7Fd14rXifAYUA
 github.com/rogpeppe/go-internal v1.8.0/go.mod h1:WmiCO8CzOY8rg0OYDC4/i/2WRWAB6poM+XZ2dLUbcbE=
 github.com/stretchr/testify v1.10.0 h1:Xv5erBjTwe/5IxqUQTdXv5kgmIvbHo3QQyRwhJsOfJA=
 github.com/stretchr/testify v1.10.0/go.mod h1:r2ic/lqez/lEtzL7wO/rwa5dbSLXVDPFyf8C91i36aY=
-golang.org/x/sys v0.29.0 h1:TPYlXGxvx1MGTn2GiZDhnjPA9wZzZeGKHHmKhHYvgaU=
-golang.org/x/sys v0.29.0/go.mod h1:/VUhepiaJMQUp4+oa/7Zr1D23ma6VTLIYjOOTFZPUcA=
+golang.org/x/sys v0.30.0 h1:QjkSwP/36a20jFYWkSue1YwXzLmsV5Gfq7Eiy72C1uc=
+golang.org/x/sys v0.30.0/go.mod h1:/VUhepiaJMQUp4+oa/7Zr1D23ma6VTLIYjOOTFZPUcA=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
 gopkg.in/check.v1 v1.0.0-20180628173108-788fd7840127/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
 gopkg.in/check.v1 v1.0.0-20201130134442-10cb98267c6c h1:Hei/4ADfdWqJk1ZMxUNpqntNwaWcugrBjAiHlqqRiVk=

--- a/node.go
+++ b/node.go
@@ -539,7 +539,7 @@ Walk:
 				if strings.HasSuffix(path, "/") {
 					// Tsr recommendation: remove the extra trailing slash (got an exact match)
 					remainingPrefix := current.key[:charsMatchedInNodeFound]
-					if len(remainingPrefix) == 1 && remainingPrefix[0] == slashDelim {
+					if parent != nil && parent.isLeaf() && len(remainingPrefix) == 1 && remainingPrefix[0] == slashDelim {
 						tsr = true
 						n = parent
 						// Save also a copy of the matched params, it should not allocate anything in most case.


### PR DESCRIPTION
**Fix panic when an intermediary node is mistakenly treated as a TSR recommendation node.**  

This issue occurs when a request (e.g., `/test/`) partially matches a child node (e.g., `/x`), triggering a trailing slash redirect to the parent (`/test`). However, the parent node is an intermediary node, not a valid route, leading to a panic.  

Example:  

```
path: GET
      path: /test
          path: /x [leaf=/test/x]
          path: s/ [leaf=/tests/]
```