### PR TITLE
Add support for manually invoking the NoRoute handler

### DIFF
--- a/options.go
+++ b/options.go
@@ -57,7 +57,7 @@ func WithNoRouteHandler(handler HandlerFunc) GlobalOption {
 		if handler == nil {
 			return fmt.Errorf("%w: no route handler cannot be nil", ErrInvalidConfig)
 		}
-		s.router.noRoute = handler
+		s.router.noRouteBase = handler
 		return nil
 	})
 }

--- a/response_writer.go
+++ b/response_writer.go
@@ -328,9 +328,7 @@ func relevantCaller() runtime.Frame {
 	return frame
 }
 
-var errHttpNotSupported = fmt.Errorf("%w", http.ErrNotSupported)
-
 // ErrNotSupported returns an error that Is http.ErrNotSupported, but is not == to it.
 func ErrNotSupported() error {
-	return errHttpNotSupported
+	return fmt.Errorf("%w", http.ErrNotSupported)
 }


### PR DESCRIPTION
### Summary

This PR introduces a simple yet useful addition: it enables developers to explicitly invoke the `NoRoute` handler from within a handler.

A common use case is serving static content. For instance, it's quite common to write a small helper for a static file server in order to provide a custom 404 page when a requested file is missing. Here's an example of how you can achieve that.

```go
fileServer := Static("/", "./public/404.html", http.Dir("./public"))

fx.MustHandle(http.MethodGet, "/", fileServer)
fx.MustHandle(http.MethodGet, "/*{filepath}", fileServer)

func Static(prefix, notFoundFile string, fs http.FileSystem) fox.HandlerFunc {
	fileServer := http.StripPrefix(prefix, http.FileServer(fs))
	return func(c fox.Context) {
		file := c.Param("filepath")
		f, err := fs.Open(file)
		if err != nil {
			http.ServeFile(c.Writer(), c.Request(), notFoundFile)
			return
		}
		_ = f.Close()
		fileServer.ServeHTTP(c.Writer(), c.Request())
	}
}
```

While this works, a cleaner and more extensible approach is to leverage Fox's `NoRoute` handler, where the fallback logic may be centralized. However, when matching routes like `/*{filepath}`, the `NoRoute` handler is never reached because the wildcard matches all requests — even those for missing files. As a result, it’s actually the `http.FileServer` that ends up returning the 404.

This PR introduces a small but effective change: we expose a method that allows invoking the configured `NoRoute` handler manually from within a handler. This makes it easier to handle such cases explicitly and in a more idiomatic way:

```go
fx, _ := fox.New(
    fox.WithNoRouteHandler(func(c fox.Context) {
        if path.Ext(c.Param("filepath")) == "" {
            http.ServeFile(c.Writer(), c.Request(), "./public/404.html")
            return
        }
        fox.DefaultNotFoundHandler(c)
    }),
)

fileServer := Static("/", http.Dir("./public"))

fx.MustHandle(http.MethodGet, "/", fileServer)
fx.MustHandle(http.MethodGet, "/*{filepath}", fileServer)

func Static(prefix string, fs http.FileSystem) fox.HandlerFunc {
	fileServer := http.StripPrefix(prefix, http.FileServer(fs))
	return func(c fox.Context) {
		file := c.Param("filepath")
		f, err := fs.Open(file)
		if err != nil {
			c.Fox().HandleNoRoute(c)
			return
		}
		_ = f.Close()
		fileServer.ServeHTTP(c.Writer(), c.Request())
	}
}
```

This makes the logic more versatile and composable.

At this point, I don't see a strong reason to expose the same mechanism for `NoMethod` or `AutoOptions` handlers, as those are generally tied to the router's internal dispatch logic.