### PR TITLE
feat(validation): improve route and HTTP method validation

### DIFF
--- a/fox.go
+++ b/fox.go
@@ -11,7 +11,6 @@ import (
 	"net"
 	"net/http"
 	"path"
-	"regexp"
 	"strconv"
 	"strings"
 	"sync"
@@ -29,8 +28,6 @@ const (
 )
 
 var (
-	// regEnLetter matches english letters for http method name.
-	regEnLetter = regexp.MustCompile("^[A-Z]+$")
 	// commonVerbs define http method for which node are pre instantiated.
 	commonVerbs = [verb]string{http.MethodGet, http.MethodPost, http.MethodPut, http.MethodDelete}
 )
@@ -811,6 +808,12 @@ func (fox *Router) parseRoute(url string) (uint32, int, error) {
 						return 0, -1, fmt.Errorf("%w: illegal character '%s' in hostname label", ErrInvalidRoute, string(c))
 					}
 					last = c
+				} else {
+					c := url[i]
+					// reject any ASCII control character.
+					if c < ' ' || c == 0x7f {
+						return 0, -1, fmt.Errorf("%w: illegal control character in path", ErrInvalidRoute)
+					}
 				}
 			}
 

--- a/go.mod
+++ b/go.mod
@@ -7,6 +7,7 @@ toolchain go1.24.0
 require (
 	github.com/google/gofuzz v1.2.0
 	github.com/stretchr/testify v1.10.0
+	golang.org/x/net v0.41.0
 	golang.org/x/sys v0.33.0
 )
 
@@ -15,6 +16,7 @@ require (
 	github.com/kr/pretty v0.3.0 // indirect
 	github.com/pmezard/go-difflib v1.0.0 // indirect
 	github.com/rogpeppe/go-internal v1.8.0 // indirect
+	golang.org/x/text v0.26.0 // indirect
 	gopkg.in/check.v1 v1.0.0-20201130134442-10cb98267c6c // indirect
 	gopkg.in/yaml.v3 v3.0.1 // indirect
 )

--- a/go.sum
+++ b/go.sum
@@ -19,8 +19,12 @@ github.com/rogpeppe/go-internal v1.8.0 h1:FCbCCtXNOY3UtUuHUYaghJg4y7Fd14rXifAYUA
 github.com/rogpeppe/go-internal v1.8.0/go.mod h1:WmiCO8CzOY8rg0OYDC4/i/2WRWAB6poM+XZ2dLUbcbE=
 github.com/stretchr/testify v1.10.0 h1:Xv5erBjTwe/5IxqUQTdXv5kgmIvbHo3QQyRwhJsOfJA=
 github.com/stretchr/testify v1.10.0/go.mod h1:r2ic/lqez/lEtzL7wO/rwa5dbSLXVDPFyf8C91i36aY=
+golang.org/x/net v0.41.0 h1:vBTly1HeNPEn3wtREYfy4GZ/NECgw2Cnl+nK6Nz3uvw=
+golang.org/x/net v0.41.0/go.mod h1:B/K4NNqkfmg07DQYrbwvSluqCJOOXwUjeb/5lOisjbA=
 golang.org/x/sys v0.33.0 h1:q3i8TbbEz+JRD9ywIRlyRAQbM0qF7hu24q3teo2hbuw=
 golang.org/x/sys v0.33.0/go.mod h1:BJP2sWEmIv4KK5OTEluFJCKSidICx8ciO85XgH3Ak8k=
+golang.org/x/text v0.26.0 h1:P42AVeLghgTYr4+xUnTRKDMqpar+PtX7KWuNQL21L8M=
+golang.org/x/text v0.26.0/go.mod h1:QK15LZJUUQVJxhz7wXgxSy/CJaTFjd0G+YLonydOVQA=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
 gopkg.in/check.v1 v1.0.0-20180628173108-788fd7840127/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
 gopkg.in/check.v1 v1.0.0-20201130134442-10cb98267c6c h1:Hei/4ADfdWqJk1ZMxUNpqntNwaWcugrBjAiHlqqRiVk=

--- a/tree.go
+++ b/tree.go
@@ -692,7 +692,7 @@ func isRemovable(method string) bool {
 func (t *iTree) allocateContext() *cTx {
 	params := make(Params, 0, t.maxParams)
 	tsrParams := make(Params, 0, t.maxParams)
-	skipNds := make(skippedNodes, 0, t.depth)
+	skipNds := make(skippedNodes, 0, t.depth*2) // 2x since at each level, we may skip param and wildcard
 	return &cTx{
 		params:    &params,
 		skipNds:   &skipNds,


### PR DESCRIPTION
### Change:
- Replace regex method validation with httpguts.IsTokenRune for RFC compliance
- Add validation for ASCII control characters in path segments
- Increase skippedNodes capacity to 2x depth for param/wildcard handling (optimization)
- Add test cases for control character validation in methods and paths
- Add golang.org/x/net dependency for httpguts package