### PR TITLE
Add configurable redirect trailing slash handler

### DIFF
--- a/fox_test.go
+++ b/fox_test.go
@@ -5084,6 +5084,20 @@ func TestEncodedRedirectTrailingSlash(t *testing.T) {
 	assert.Equal(t, "bar%2Fbaz/", w.Header().Get(HeaderLocation))
 }
 
+func TestWithRedirectTrailingSlashHandler(t *testing.T) {
+	r, _ := New(WithRedirectTrailingSlashHandler(func(c Context) {
+		_ = c.Redirect(http.StatusMovedPermanently, FixTrailingSlash(c.Path()))
+	}))
+	require.NoError(t, onlyError(r.Handle(http.MethodGet, "/foo/bar/", emptyHandler)))
+
+	req := httptest.NewRequest(http.MethodGet, "/foo/bar", nil)
+	w := httptest.NewRecorder()
+
+	r.ServeHTTP(w, req)
+	assert.Equal(t, http.StatusMovedPermanently, w.Code)
+	assert.Equal(t, "/foo/bar/", w.Header().Get(HeaderLocation))
+}
+
 func TestRouterWithTsrParams(t *testing.T) {
 	cases := []struct {
 		name       string


### PR DESCRIPTION
This PR introduces the ability to customize the trailing slash redirect behavior in Fox by adding a new `WithRedirectTrailingSlashHandler` option.

## Changes

- **New public function**: `DefaultRedirectTrailingSlashHandler` - The default handler that was previously private (`defaultRedirectTrailingSlashHandler`) is now public and properly documented
- **New option**: `WithRedirectTrailingSlashHandler` - Allows users to provide a custom handler for trailing slash redirects
- **Improved flexibility**: Users can now implement custom redirect logic, such as:
  - Using absolute URLs instead of relative redirects
  - Custom status codes
  - Additional headers or logic during redirects

## Example Usage

```go
// Use a custom redirect handler
r, _ := fox.New(fox.WithRedirectTrailingSlashHandler(func(c fox.Context) {
    // Custom redirect logic
    _ = c.Redirect(http.StatusMovedPermanently, fox.FixTrailingSlash(c.Path()))
}))
```

## Behavior

- The new option automatically enables `WithRedirectTrailingSlash`
- It's mutually exclusive with `WithIgnoreTrailingSlash` - enabling this option will disable ignore trailing slash
- The default behavior remains unchanged if the option is not used
