### PR TITLE
Only mark hijacked on successful hijack

### DIFF
--- a/response_writer.go
+++ b/response_writer.go
@@ -6,6 +6,7 @@ package fox
 
 import (
 	"bufio"
+	"errors"
 	"fmt"
 	"io"
 	"log"
@@ -235,8 +236,11 @@ func (r *recorder) Push(target string, opts *http.PushOptions) error {
 // an error matching [http.ErrNotSupported]. See [http.Hijacker] for more details.
 func (r *recorder) Hijack() (net.Conn, *bufio.ReadWriter, error) {
 	if hijacker, ok := r.ResponseWriter.(http.Hijacker); ok {
-		r.hijacked = true
-		return hijacker.Hijack()
+		c, rw, err := hijacker.Hijack()
+		if !errors.Is(err, http.ErrNotSupported) && !errors.Is(err, http.ErrHijacked) {
+			r.hijacked = true
+		}
+		return c, rw, err
 	}
 	return nil, nil, ErrNotSupported()
 }

--- a/response_writer_test.go
+++ b/response_writer_test.go
@@ -142,6 +142,7 @@ func TestRecorder_Hijack(t *testing.T) {
 			assert: func(t *testing.T, w ResponseWriter) {
 				_, _, err := w.Hijack()
 				assert.NoError(t, err)
+				assert.True(t, w.(*recorder).hijacked)
 			},
 		},
 		{
@@ -152,6 +153,45 @@ func TestRecorder_Hijack(t *testing.T) {
 			assert: func(t *testing.T, w ResponseWriter) {
 				_, _, err := w.Hijack()
 				assert.ErrorIs(t, err, http.ErrNotSupported)
+				assert.False(t, w.(*recorder).hijacked)
+			},
+		},
+		{
+			name: "underlying hijacker returns http.ErrNotSupported does not mark hijacked",
+			rec: &recorder{
+				ResponseWriter: struct {
+					http.ResponseWriter
+					http.Hijacker
+				}{
+					ResponseWriter: httptest.NewRecorder(),
+					Hijacker: hijackWriterFunc(func() (net.Conn, *bufio.ReadWriter, error) {
+						return nil, nil, http.ErrNotSupported
+					}),
+				},
+			},
+			assert: func(t *testing.T, w ResponseWriter) {
+				_, _, err := w.Hijack()
+				assert.ErrorIs(t, err, http.ErrNotSupported)
+				assert.False(t, w.(*recorder).hijacked)
+			},
+		},
+		{
+			name: "underlying hijacker returns http.ErrHijacked does not mark hijacked",
+			rec: &recorder{
+				ResponseWriter: struct {
+					http.ResponseWriter
+					http.Hijacker
+				}{
+					ResponseWriter: httptest.NewRecorder(),
+					Hijacker: hijackWriterFunc(func() (net.Conn, *bufio.ReadWriter, error) {
+						return nil, nil, http.ErrHijacked
+					}),
+				},
+			},
+			assert: func(t *testing.T, w ResponseWriter) {
+				_, _, err := w.Hijack()
+				assert.ErrorIs(t, err, http.ErrHijacked)
+				assert.False(t, w.(*recorder).hijacked)
 			},
 		},
 	}


### PR DESCRIPTION
`recorder.Hijack` previously set hijacked = true before checking the hijacker's return value. If the underlying hijacker returned `http.ErrNotSupported` or `http.ErrHijacked`, the recorder would still be marked as hijacked, causing subsequent Write/WriteHeader calls to wrongly fail with `http.ErrHijacked`. The flag is now only set when Hijack actually succeeds.  