### PR TITLE
Add EscapedPath() and use it for routing-aware redirects and logs

### DIFF
--- a/context.go
+++ b/context.go
@@ -45,7 +45,13 @@ type RequestContext interface {
 	// Method returns the request method.
 	Method() string
 	// Path returns the request [url.URL.RawPath] if not empty, or fallback to the [url.URL.Path].
+	// For the canonical encoded form used by the router, prefer [RequestContext.EscapedPath].
 	Path() string
+	// EscapedPath returns the canonical encoded path that the router uses for matching.
+	// It is equivalent to [url.URL.EscapedPath] with hex sequences normalized to uppercase
+	// (e.g. %2f becomes %2F). Use this when the form must match exactly what the router
+	// routed on, such as when constructing redirect targets, cache keys, or routing logs.
+	EscapedPath() string
 	// Host returns the request host.
 	Host() string
 	// QueryParams parses the [http.Request] raw query and returns the corresponding values. The result is cached after
@@ -207,11 +213,20 @@ func (c *Context) Method() string {
 }
 
 // Path returns the request [url.URL.RawPath] if not empty, or fallback to the [url.URL.Path].
+// For the canonical encoded form used by the router, prefer [Context.EscapedPath].
 func (c *Context) Path() string {
 	if len(c.req.URL.RawPath) > 0 {
 		return c.req.URL.RawPath
 	}
 	return c.req.URL.Path
+}
+
+// EscapedPath returns the canonical encoded path that the router uses for matching.
+// It is equivalent to [url.URL.EscapedPath] with hex sequences normalized to uppercase
+// (e.g. %2f becomes %2F). Use this when the form must match exactly what the router
+// routed on, such as when constructing redirect targets, cache keys, or routing logs.
+func (c *Context) EscapedPath() string {
+	return routingPath(c.req)
 }
 
 // Host returns the request host.
@@ -352,7 +367,7 @@ func (c *Context) CloneWith(w ResponseWriter, r *http.Request) *Context {
 }
 
 func copyWithResize[S ~[]T, T any](dst, src *S) {
-	if len(*src) > len(*dst) { // TODO could be cap(*dst)
+	if len(*src) > cap(*dst) {
 		// Grow dst cap to a least len(src)
 		*dst = slices.Grow(*dst, len(*src)-len(*dst))
 	}

--- a/context_test.go
+++ b/context_test.go
@@ -114,6 +114,59 @@ func TestContext_Path(t *testing.T) {
 	assert.Equal(t, "/foo", w.Body.String())
 }
 
+func TestContext_EscapedPath(t *testing.T) {
+	t.Parallel()
+	cases := []struct {
+		name   string
+		target string
+		want   string
+	}{
+		{
+			name:   "ascii canonical",
+			target: "https://example.com/foo/bar",
+			want:   "/foo/bar",
+		},
+		{
+			name:   "encoded space normalizes encoding",
+			target: "https://example.com/foo%20bar",
+			want:   "/foo%20bar",
+		},
+		{
+			name:   "encoded sub-delim preserved",
+			target: "https://example.com/foo%21bar",
+			want:   "/foo%21bar",
+		},
+		{
+			name:   "encoded non-ascii preserved",
+			target: "https://example.com/foo%C3%A9bar",
+			want:   "/foo%C3%A9bar",
+		},
+		{
+			name:   "lowercase hex normalized to uppercase",
+			target: "https://example.com/foo%2fbar",
+			want:   "/foo%2Fbar",
+		},
+		{
+			name:   "encoded slash preserved as raw path",
+			target: "https://example.com/foo/bar%2Fbaz",
+			want:   "/foo/bar%2Fbaz",
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			f, _ := NewRouter()
+			f.MustAdd(MethodGet, "/*{any}", func(c *Context) {
+				_, _ = io.WriteString(c.Writer(), c.EscapedPath())
+			})
+
+			w := httptest.NewRecorder()
+			r := httptest.NewRequest(http.MethodGet, tc.target, nil)
+			f.ServeHTTP(w, r)
+			assert.Equal(t, tc.want, w.Body.String())
+		})
+	}
+}
+
 func TestContext_Host(t *testing.T) {
 	t.Parallel()
 	f, _ := NewRouter()

--- a/fox.go
+++ b/fox.go
@@ -366,7 +366,7 @@ func (fox *Router) Match(method string, r *http.Request) (route *Route, tsr bool
 	defer tree.pool.Put(c)
 	c.resetWithRequest(r)
 
-	path := routingPath(r)
+	path := c.EscapedPath()
 
 	idx, n, tsr := tree.lookup(method, r.Host, path, c, true)
 	if n != nil {
@@ -385,7 +385,7 @@ func (fox *Router) Lookup(w ResponseWriter, r *http.Request) (route *Route, cc *
 	c := tree.pool.Get().(*Context)
 	c.resetWithWriter(w, r)
 
-	path := routingPath(r)
+	path := c.EscapedPath()
 
 	idx, n, tsr := tree.lookup(r.Method, r.Host, path, c, false)
 	if n != nil {
@@ -593,7 +593,7 @@ func (fox *Router) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	c := tree.pool.Get().(*Context)
 	c.reset(w, r)
 
-	path := routingPath(r)
+	path := c.EscapedPath()
 
 	idx, n, tsr := tree.lookup(r.Method, r.Host, path, c, false)
 	if !tsr && n != nil {
@@ -1000,7 +1000,7 @@ func Sub(router *Router) HandlerFunc {
 		// reslice from the original path to include it, avoiding an allocation from "/" + suffix.
 		suffix := cmp.Or((*c.params)[len(*c.params)-1], "/")
 		if !strings.HasPrefix(suffix, "/") {
-			path := routingPath(c.req)
+			path := c.EscapedPath()
 			slashPos := len(path) - len(suffix) - 1
 			if path[slashPos] == slashDelim {
 				suffix = path[slashPos:]
@@ -1051,7 +1051,7 @@ func internalTrailingSlashHandler(c *Context) {
 		code = http.StatusPermanentRedirect
 	}
 
-	path := escapeLeadingSlashes(fixTrailingSlash(c.Path()))
+	path := escapeLeadingSlashes(fixTrailingSlash(c.EscapedPath()))
 	if q := req.URL.RawQuery; q != "" {
 		path += "?" + q
 	}
@@ -1068,7 +1068,7 @@ func internalFixedPathHandler(c *Context) {
 		code = http.StatusPermanentRedirect
 	}
 
-	cleanedPath := escapeLeadingSlashes(CleanPath(c.Path()))
+	cleanedPath := escapeLeadingSlashes(CleanPath(c.EscapedPath()))
 	if q := req.URL.RawQuery; q != "" {
 		cleanedPath += "?" + q
 	}

--- a/fox_test.go
+++ b/fox_test.go
@@ -2706,6 +2706,33 @@ func TestRouter_ServeHTTP_RedirectFixedPath(t *testing.T) {
 			wantCode:     http.StatusMovedPermanently,
 			wantLocation: "/foo/bar?1=2",
 		},
+		{
+			name:         "consecutive slash with encoded space in segment",
+			path:         "/foo/{bar}",
+			slashMode:    StrictSlash,
+			req:          "/foo//baz%20qux",
+			method:       http.MethodGet,
+			wantCode:     http.StatusMovedPermanently,
+			wantLocation: "/foo/baz%20qux",
+		},
+		{
+			name:         "consecutive slash with lowercase hex in segment",
+			path:         "/foo/{bar}",
+			slashMode:    StrictSlash,
+			req:          "/foo//baz%2fqux",
+			method:       http.MethodGet,
+			wantCode:     http.StatusMovedPermanently,
+			wantLocation: "/foo/baz%2Fqux",
+		},
+		{
+			name:         "consecutive slash with encoded sub-delim in segment",
+			path:         "/foo/{bar}",
+			slashMode:    StrictSlash,
+			req:          "/foo//baz%21qux",
+			method:       http.MethodGet,
+			wantCode:     http.StatusMovedPermanently,
+			wantLocation: "/foo/baz%21qux",
+		},
 	}
 
 	for _, tc := range cases {
@@ -2928,6 +2955,41 @@ func TestRouter_ServeHTTP_EncodedRedirectTrailingSlash(t *testing.T) {
 			req:          "/\\evil.com",
 			wantCode:     http.StatusMovedPermanently,
 			wantLocation: "/%5Cevil.com/",
+		},
+		{
+			name:         "encoded space normalized in redirect",
+			path:         "/foo/{bar}/",
+			req:          "/foo/baz%20qux",
+			wantCode:     http.StatusMovedPermanently,
+			wantLocation: "/foo/baz%20qux/",
+		},
+		{
+			name:         "encoded sub-delim preserved in redirect",
+			path:         "/foo/{bar}/",
+			req:          "/foo/baz%21qux",
+			wantCode:     http.StatusMovedPermanently,
+			wantLocation: "/foo/baz%21qux/",
+		},
+		{
+			name:         "encoded non-ascii preserved in redirect",
+			path:         "/foo/{bar}/",
+			req:          "/foo/baz%C3%A9qux",
+			wantCode:     http.StatusMovedPermanently,
+			wantLocation: "/foo/baz%C3%A9qux/",
+		},
+		{
+			name:         "lowercase hex normalized to uppercase in redirect",
+			path:         "/foo/{bar}/",
+			req:          "/foo/baz%2fqux",
+			wantCode:     http.StatusMovedPermanently,
+			wantLocation: "/foo/baz%2Fqux/",
+		},
+		{
+			name:         "encoded crlf preserved encoded in redirect",
+			path:         "/foo/{bar}/",
+			req:          "/foo/baz%0D%0Aqux",
+			wantCode:     http.StatusMovedPermanently,
+			wantLocation: "/foo/baz%0D%0Aqux/",
 		},
 	}
 

--- a/logger.go
+++ b/logger.go
@@ -21,7 +21,8 @@ const (
 	// LoggerHostKey is the key used by the built-in logger middleware for the request host.
 	// The associated [slog.Value] is a string.
 	LoggerHostKey = "host"
-	// LoggerPathKey is the key used by the built-in logger middleware for the request path.
+	// LoggerPathKey is the key used by the built-in logger middleware for the canonical encoded
+	// request path the router routed on (see [Context.EscapedPath]).
 	// The associated [slog.Value] is a string.
 	LoggerPathKey = "path"
 	// LoggerLatencyKey is the key used by the built-in logger middleware for the request processing duration.
@@ -68,7 +69,7 @@ func Logger(handler slog.Handler) MiddlewareFunc {
 				slog.Int(LoggerStatusKey, c.Writer().Status()),
 				slog.String(LoggerMethodKey, c.Method()),
 				slog.String(LoggerHostKey, c.Host()),
-				slog.String(LoggerPathKey, c.Path()),
+				slog.String(LoggerPathKey, c.EscapedPath()),
 				slog.Int(LoggerSizeKey, c.Writer().Size()),
 				slog.Duration(LoggerLatencyKey, latency),
 			)

--- a/logger_test.go
+++ b/logger_test.go
@@ -34,6 +34,9 @@ func TestLogger(t *testing.T) {
 	require.NoError(t, onlyError(f.Add(MethodGet, "/failure", func(c *Context) {
 		c.Writer().WriteHeader(http.StatusInternalServerError)
 	})))
+	require.NoError(t, onlyError(f.Add(MethodGet, "/echo/{name}", func(c *Context) {
+		c.Writer().WriteHeader(http.StatusOK)
+	})))
 
 	cases := []struct {
 		name string
@@ -59,6 +62,16 @@ func TestLogger(t *testing.T) {
 			name: "should log debug level",
 			req:  httptest.NewRequest(http.MethodGet, "/success/", nil),
 			want: "time=time level=DEBUG msg=192.0.2.1 status=301 method=GET host=example.com path=/success/ size=43 latency=latency location=/success\n",
+		},
+		{
+			name: "should log canonical encoded path with uppercase hex",
+			req:  httptest.NewRequest(http.MethodGet, "/echo/jean%20dupont", nil),
+			want: "time=time level=INFO msg=192.0.2.1 status=200 method=GET host=example.com path=/echo/jean%20dupont size=0 latency=latency\n",
+		},
+		{
+			name: "should normalize lowercase hex in logged path",
+			req:  httptest.NewRequest(http.MethodGet, "/echo/foo%2fbar", nil),
+			want: "time=time level=INFO msg=192.0.2.1 status=200 method=GET host=example.com path=/echo/foo%2Fbar size=0 latency=latency\n",
 		},
 	}
 

--- a/options.go
+++ b/options.go
@@ -112,7 +112,7 @@ func WithOptionsHandler(handler HandlerFunc) GlobalOption {
 //   - RelaxedSlash: Routes match regardless of trailing slash. Both /foo/bar and /foo/bar/ match the same route.
 //   - RedirectSlash: When a route is not found, but exists with/without a trailing slash, issues a redirect to the correct path.
 //
-// Redirects use URL.RawPath if set, otherwise URL.Path.
+// Redirects use the canonical encoded path that the router routed on (see [Context.EscapedPath]).
 //
 // This option can be applied on a per-route basis or globally:
 //   - If applied globally, it affects all routes by default.
@@ -149,7 +149,7 @@ func WithHandleTrailingSlash(opt TrailingSlashOption) interface {
 //   - RelaxedPath: After normal lookup fails, tries matching with a cleaned path. If found, serves the handler directly.
 //   - RedirectPath: After normal lookup fails, tries matching with a cleaned path. If found, redirects to the clean path.
 //
-// Redirects use URL.RawPath if set, otherwise URL.Path.
+// Redirects use the canonical encoded path that the router routed on (see [Context.EscapedPath]).
 //
 // This option applies globally to all routes and cannot be configured per-route. See [CleanPath] for details on how
 // paths are cleaned.

--- a/txn.go
+++ b/txn.go
@@ -290,7 +290,7 @@ func (txn *Txn) Match(method string, r *http.Request) (route *Route, tsr bool) {
 	defer tree.pool.Put(c)
 	c.resetWithRequest(r)
 
-	path := routingPath(r)
+	path := c.EscapedPath()
 
 	idx, n, tsr := txn.rootTxn.patterns.lookup(method, r.Host, path, c, true)
 	if n != nil {
@@ -313,7 +313,7 @@ func (txn *Txn) Lookup(w ResponseWriter, r *http.Request) (route *Route, cc *Con
 	c := tree.pool.Get().(*Context)
 	c.resetWithWriter(w, r)
 
-	path := routingPath(r)
+	path := c.EscapedPath()
 
 	idx, n, tsr := txn.rootTxn.patterns.lookup(r.Method, r.Host, path, c, false)
 	if n != nil {


### PR DESCRIPTION
## Summary

This PR exposes a new method on the `RequestContext` that returns the canonical encoded path the router uses for matching (`c.EscapedPath()`). It is equivalent to `URL.EscapedPath()` with hex sequences normalized to uppercase, and is now used across `ServeHTTP`, `Match`, `Lookup`, `serveSubRouter`, and the `Txn` equivalents in place of the internal `routingPath()` helper. The internal redirect handlers and the `Logger` middleware also switch to it so that what gets redirected and logged matches exactly what the router routed on.

## Motivation

The internal redirect handlers (`internalTrailingSlashHandler`, `internalFixedPathHandler`) and the `Logger` middleware previously used `c.Path()`, which returns `URL.RawPath` if set, otherwise the decoded `URL.Path`. The router itself routes on `EscapedPath()` + uppercase hex normalization, so there was a divergence:

- A request to `/foo%20bar` would route on `/foo%20bar` but redirect to `/foo bar/` (literal space in `Location` header).
- A request to `/foo%2fbar` (lowercase hex) would route on `/foo%2Fbar` but redirect to `/foo%2fbar`.
- Decoded sub-delims and non-ASCII bytes leaked into the `Location` header and into the `path` log field.

Aligning these handlers and the logger on the same canonical form the router operates on removes the inconsistency and makes log entries match the form the router actually decided on.
