### PR TITLE
Add scheme matcher for routing on TLS state

### DIFF
--- a/matcher.go
+++ b/matcher.go
@@ -6,6 +6,7 @@ import (
 	"net"
 	"net/http"
 	"regexp"
+	"strings"
 
 	"github.com/fox-toolkit/fox/internal/netutil"
 )
@@ -242,4 +243,37 @@ func (m ClientIpMatcher) Equal(matcher Matcher) bool {
 
 func (m ClientIpMatcher) String() string {
 	return "ip:" + m.ipNet.String()
+}
+
+func MatchScheme(scheme string) (SchemeMatcher, error) {
+	s := strings.ToLower(scheme)
+	if s != "http" && s != "https" {
+		return SchemeMatcher{}, errors.New(`scheme must be "http" or "https"`)
+	}
+	return SchemeMatcher{scheme: s}, nil
+}
+
+type SchemeMatcher struct {
+	scheme string
+}
+
+func (m SchemeMatcher) Scheme() string {
+	return m.scheme
+}
+
+func (m SchemeMatcher) Match(c RequestContext) bool {
+	isHTTPS := c.Request().TLS != nil
+	return isHTTPS == (m.scheme == "https")
+}
+
+func (m SchemeMatcher) Equal(matcher Matcher) bool {
+	om, ok := matcher.(SchemeMatcher)
+	if !ok {
+		return false
+	}
+	return m.scheme == om.scheme
+}
+
+func (m SchemeMatcher) String() string {
+	return "s:" + m.scheme
 }

--- a/matcher_test.go
+++ b/matcher_test.go
@@ -1,6 +1,7 @@
 package fox
 
 import (
+	"crypto/tls"
 	"net"
 	"net/http"
 	"net/http/httptest"
@@ -646,6 +647,170 @@ func TestMatchHeaderRegexp(t *testing.T) {
 			assert.NoError(t, err)
 			assert.Equal(t, tc.wantKey, m.Key())
 			assert.NotNil(t, m.Regex())
+		})
+	}
+}
+
+func TestSchemeMatcher_Match(t *testing.T) {
+	cases := []struct {
+		name      string
+		scheme    string
+		urlScheme string
+		tls       bool
+		want      bool
+	}{
+		{
+			name:   "match https with TLS",
+			scheme: "https",
+			tls:    true,
+			want:   true,
+		},
+		{
+			name:   "match http without TLS",
+			scheme: "http",
+			tls:    false,
+			want:   true,
+		},
+		{
+			name:   "no match https without TLS",
+			scheme: "https",
+			tls:    false,
+			want:   false,
+		},
+		{
+			name:   "no match http with TLS",
+			scheme: "http",
+			tls:    true,
+			want:   false,
+		},
+		{
+			name:      "no spoof via r.URL.Scheme without TLS",
+			scheme:    "https",
+			urlScheme: "https",
+			tls:       false,
+			want:      false,
+		},
+		{
+			name:      "no spoof via r.URL.Scheme with TLS",
+			scheme:    "http",
+			urlScheme: "http",
+			tls:       true,
+			want:      false,
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			m := SchemeMatcher{scheme: tc.scheme}
+			req := httptest.NewRequest(http.MethodGet, "/path", nil)
+			if tc.urlScheme != "" {
+				req.URL.Scheme = tc.urlScheme
+			} else {
+				req.URL.Scheme = ""
+			}
+			if tc.tls {
+				req.TLS = &tls.ConnectionState{}
+			} else {
+				req.TLS = nil
+			}
+			w := httptest.NewRecorder()
+			c := NewTestContextOnly(w, req)
+			assert.Equal(t, tc.want, m.Match(c))
+		})
+	}
+}
+
+func TestSchemeMatcher_Equal(t *testing.T) {
+	cases := []struct {
+		name string
+		m1   SchemeMatcher
+		m2   Matcher
+		want bool
+	}{
+		{
+			name: "equal matchers",
+			m1:   SchemeMatcher{scheme: "https"},
+			m2:   SchemeMatcher{scheme: "https"},
+			want: true,
+		},
+		{
+			name: "different scheme",
+			m1:   SchemeMatcher{scheme: "https"},
+			m2:   SchemeMatcher{scheme: "http"},
+			want: false,
+		},
+		{
+			name: "different type",
+			m1:   SchemeMatcher{scheme: "https"},
+			m2:   QueryMatcher{key: "scheme", value: "https"},
+			want: false,
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			assert.Equal(t, tc.want, tc.m1.Equal(tc.m2))
+		})
+	}
+}
+
+func TestSchemeMatcher_String(t *testing.T) {
+	m := SchemeMatcher{scheme: "https"}
+	assert.Equal(t, "s:https", m.String())
+}
+
+func TestMatchScheme(t *testing.T) {
+	cases := []struct {
+		name       string
+		scheme     string
+		wantErr    bool
+		wantScheme string
+	}{
+		{
+			name:       "valid http",
+			scheme:     "http",
+			wantErr:    false,
+			wantScheme: "http",
+		},
+		{
+			name:       "valid https",
+			scheme:     "https",
+			wantErr:    false,
+			wantScheme: "https",
+		},
+		{
+			name:       "uppercase HTTPS gets canonicalized",
+			scheme:     "HTTPS",
+			wantErr:    false,
+			wantScheme: "https",
+		},
+		{
+			name:       "mixed case Https gets canonicalized",
+			scheme:     "Https",
+			wantErr:    false,
+			wantScheme: "https",
+		},
+		{
+			name:    "invalid scheme ws",
+			scheme:  "ws",
+			wantErr: true,
+		},
+		{
+			name:    "empty scheme",
+			scheme:  "",
+			wantErr: true,
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			m, err := MatchScheme(tc.scheme)
+			if tc.wantErr {
+				assert.Error(t, err)
+				return
+			}
+			assert.NoError(t, err)
+			assert.Equal(t, tc.wantScheme, m.Scheme())
 		})
 	}
 }

--- a/options.go
+++ b/options.go
@@ -447,6 +447,29 @@ func WithClientIPMatcher(ip string) interface {
 	})
 }
 
+// WithSchemeMatcher attaches a URL scheme matcher to a route. The matcher ensures that requests are
+// only routed to the handler if the connection scheme matches the given value. Only "http" and "https"
+// are accepted. The scheme is ONLY derived from the TLS state of the connection between the client and
+// the server. Behind a TLS-terminating reverse proxy, this matcher therefore reflects the proxy-to-server
+// hop, not the original client connection; to route on the original client scheme (e.g. via
+// X-Forwarded-Proto), implement a custom [Matcher] that reads the header within a trust boundary you
+// control. Note that r.URL.Scheme is intentionally ignored: it can be set by an attacker via HTTP/1.1
+// absolute-form requests. Multiple matchers can be attached to the same route. All matchers
+// must match for the route to be eligible.
+func WithSchemeMatcher(scheme string) interface {
+	RouteOption
+	MatcherOption
+} {
+	return optionFunc(func(s sealedOption) error {
+		matcher, err := MatchScheme(scheme)
+		if err != nil {
+			return fmt.Errorf("%w: %w", ErrInvalidMatcher, err)
+		}
+		s.route.matchers = append(s.route.matchers, matcher)
+		return nil
+	})
+}
+
 // WithMatcher attaches a custom matcher to a route. Matchers allow for advanced request routing based
 // on conditions beyond the request host, path and method. Multiple matchers can be attached to the same route.
 // All matchers must match for the route to be eligible.

--- a/options_test.go
+++ b/options_test.go
@@ -985,6 +985,55 @@ func TestWithClientIPMatcher(t *testing.T) {
 	}
 }
 
+func TestWithSchemeMatcher(t *testing.T) {
+	cases := []struct {
+		name    string
+		scheme  string
+		wantErr bool
+	}{
+		{
+			name:    "valid http",
+			scheme:  "http",
+			wantErr: false,
+		},
+		{
+			name:    "valid https",
+			scheme:  "https",
+			wantErr: false,
+		},
+		{
+			name:    "uppercase HTTPS",
+			scheme:  "HTTPS",
+			wantErr: false,
+		},
+		{
+			name:    "invalid scheme",
+			scheme:  "ws",
+			wantErr: true,
+		},
+		{
+			name:    "empty scheme",
+			scheme:  "",
+			wantErr: true,
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			f, err := NewRouter()
+			require.NoError(t, err)
+			err = onlyError(f.Add(MethodGet, "/foo", emptyHandler, WithSchemeMatcher(tc.scheme)))
+			if tc.wantErr {
+				assert.ErrorIs(t, err, ErrInvalidMatcher)
+				return
+			}
+			require.NoError(t, err)
+			m, _ := MatchScheme(tc.scheme)
+			assert.True(t, f.Has(MethodGet, "/foo", m))
+		})
+	}
+}
+
 func TestWithMatcher(t *testing.T) {
 	t.Run("valid custom matcher", func(t *testing.T) {
 		f, err := NewRouter()


### PR DESCRIPTION
## Summary

Adds a new built-in matcher to the existing list (alongside header, query, client IP) for routing on the request scheme.

The match is derived from `r.TLS` only. We deliberately don't look at `r.URL.Scheme` because Go populates it from the request-line, which a client can set to anything via the HTTP/1.1 absolute-form (RFC 7230 §5.3.2). For example, sending `GET https://anything/path HTTP/1.1` over plain TCP is a valid request that lands on the server with `r.URL.Scheme == "https"` while `r.TLS == nil`. Same reasoning for `X-Forwarded-Proto`: it can be spoofed unless the application validates it within a trust boundary (e.g. trusted proxy list). When that's needed, users can write their own `Matcher` and decide where the trust comes from.

## Example

```go
f.Add(fox.MethodGet, "/admin", adminHandler, fox.WithSchemeMatcher("https"))
```
