### PR TITLE
fix(tree): only increment size on insert, not update

### DIFF
--- a/tree.go
+++ b/tree.go
@@ -266,15 +266,17 @@ func (t *tXn) insert(route *Route, mode insertMode) error {
 		t.patterns = newRoot
 		t.maxDepth = max(t.maxDepth, t.computePathDepth(newRoot, route.pattern.tokens))
 		t.maxParams = max(t.maxParams, len(route.params))
-		t.size++
-		if len(route.methods) > 0 && t.mode == modeInsert {
-			if !t.forked {
-				t.methods = maps.Clone(t.methods)
-				t.forked = true
-			}
+		if t.mode == modeInsert {
+			t.size++
+			if len(route.methods) > 0 {
+				if !t.forked {
+					t.methods = maps.Clone(t.methods)
+					t.forked = true
+				}
 
-			for _, method := range route.methods {
-				t.methods[method]++
+				for _, method := range route.methods {
+					t.methods[method]++
+				}
 			}
 		}
 	}


### PR DESCRIPTION
An embarrassing bug...

The insert function in tree.go was incrementing t.size unconditionally after a successful write, so every Update call inflated Len() even though no new route was added (the methods map increment was correctly gated on modeInsert, but t.size++ was not). This fix moves t.size++ inside the modeInsert guard so Update no longer drifts the route count. 