### PR TITLE
fix(parser): correct label-too-long error position

### DIFF
--- a/parser.go
+++ b/parser.go
@@ -283,7 +283,7 @@ func (fox *Router) parsePath(path string, paramCount int) ([]token, bool, int, *
 			}
 
 		default:
-			if c < ' ' || c == 0x7f {
+			if isASCIIControl(c) {
 				return nil, false, 0, newPatternError("syntax", i, i+1, "illegal control character")
 			}
 			if c == '/' && i > 0 && path[i-1] == '/' {
@@ -354,7 +354,7 @@ func (fox *Router) parseBrace(s string, delim byte, isOptional bool) (string, *r
 
 	for j := 0; j < len(name); j++ {
 		c := name[j]
-		if c < 0x20 || c == 0x7f {
+		if isASCIIControl(c) {
 			return "", nil, 0, newPatternError("parameter", 1+j, 1+j+1, "illegal control character in name")
 		}
 		switch c {
@@ -406,6 +406,12 @@ func (fox *Router) compileParamRegexp(rawRegex string) (*regexp.Regexp, *Pattern
 	}
 
 	return re, nil
+}
+
+// isASCIIControl reports whether c is an ASCII control character: a C0 byte
+// (0x00 to 0x1F) or DEL (0x7F).
+func isASCIIControl(c byte) bool {
+	return c < 0x20 || c == 0x7f
 }
 
 // braceIndex returns the index of the closing brace that balances an opening

--- a/parser.go
+++ b/parser.go
@@ -77,6 +77,7 @@ func (fox *Router) parseHostname(hostname string) ([]token, int, *PatternError) 
 		staticSinceWild int
 		partLen         int
 		totalLen        int
+		labelStart      int
 		last            = dotDelim
 		nonNumeric      bool
 	)
@@ -171,10 +172,11 @@ func (fox *Router) parseHostname(hostname string) ([]token, int, *PatternError) 
 					return nil, 0, newPatternError("syntax", i-1, i, "label ends with '-'")
 				}
 				if partLen > 63 {
-					return nil, 0, newPatternError("constraint", i-partLen, i, "label exceeds 63 characters")
+					return nil, 0, newPatternError("constraint", labelStart, i, "label exceeds 63 characters")
 				}
 				totalLen += partLen + 1 // +1 counts the current dot.
 				partLen = 0
+				labelStart = i + 1
 			case 'A' <= c && c <= 'Z':
 				return nil, 0, newPatternError("syntax", i, i+1, "uppercase character in label")
 			default:
@@ -198,7 +200,7 @@ func (fox *Router) parseHostname(hostname string) ([]token, int, *PatternError) 
 		return nil, 0, newPatternError("syntax", 0, len(hostname), "all numeric")
 	}
 	if partLen > 63 {
-		return nil, 0, newPatternError("constraint", len(hostname)-partLen, len(hostname), "label exceeds 63 characters")
+		return nil, 0, newPatternError("constraint", labelStart, len(hostname), "label exceeds 63 characters")
 	}
 	if totalLen > 253 {
 		return nil, 0, newPatternError("constraint", 0, len(hostname), "exceeds 253 characters")
@@ -351,8 +353,11 @@ func (fox *Router) parseBrace(s string, delim byte, isOptional bool) (string, *r
 	}
 
 	for j := 0; j < len(name); j++ {
-		switch name[j] {
-		// TODO: just put . and /, add also }
+		c := name[j]
+		if c < 0x20 || c == 0x7f {
+			return "", nil, 0, newPatternError("parameter", 1+j, 1+j+1, "illegal control character in name")
+		}
+		switch c {
 		case delim, '/', '*', '+', '{':
 			return "", nil, 0, newPatternError("parameter", 1+j, 1+j+1, "illegal character in name")
 		}

--- a/parser_test.go
+++ b/parser_test.go
@@ -2,7 +2,6 @@ package fox
 
 import (
 	"errors"
-	"fmt"
 	"regexp"
 	"regexp/syntax"
 	"slices"
@@ -1584,6 +1583,51 @@ func TestPatternError_Position(t *testing.T) {
 			wantEnd:    17,
 			wantMsg:    "capture group",
 		},
+		{
+			name:       "hostname label exceeds 63 chars before dot with param",
+			pattern:    strings.Repeat("a", 64) + "{b}.com/",
+			wantType:   "hostname",
+			wantReason: "constraint",
+			wantStart:  0,
+			wantEnd:    67,
+			wantMsg:    "label exceeds 63 characters",
+		},
+		{
+			name:       "hostname trailing label exceeds 63 chars with param",
+			pattern:    strings.Repeat("a", 64) + "{b}/",
+			wantType:   "hostname",
+			wantReason: "constraint",
+			wantStart:  0,
+			wantEnd:    67,
+			wantMsg:    "label exceeds 63 characters",
+		},
+		{
+			name:       "hostname middle label exceeds 63 chars with param",
+			pattern:    "a.b." + strings.Repeat("a", 64) + "{b}.com/",
+			wantType:   "hostname",
+			wantReason: "constraint",
+			wantStart:  4,
+			wantEnd:    71,
+			wantMsg:    "label exceeds 63 characters",
+		},
+		{
+			name:       "path control character in parameter name",
+			pattern:    "/foo/{a\x00b}",
+			wantType:   "path",
+			wantReason: "parameter",
+			wantStart:  7,
+			wantEnd:    8,
+			wantMsg:    "illegal control character in name",
+		},
+		{
+			name:       "hostname control character in parameter name",
+			pattern:    "{a\x7fb}.com/",
+			wantType:   "hostname",
+			wantReason: "parameter",
+			wantStart:  2,
+			wantEnd:    3,
+			wantMsg:    "illegal control character in name",
+		},
 	}
 
 	for _, tc := range cases {
@@ -1598,7 +1642,6 @@ func TestPatternError_Position(t *testing.T) {
 			assert.Equal(t, tc.wantStart, pe.Start)
 			assert.Equal(t, tc.wantEnd, pe.End)
 			assert.Contains(t, pe.Error(), tc.wantMsg)
-			fmt.Println(err)
 		})
 	}
 }


### PR DESCRIPTION
1. parseHostname's "label exceeds 63 characters" error reported the wrong start offset when the offending label contained a parameter, because the position was reconstructed from `i - partLen ` while parseBrace advances i without touching partLen
2. parseBrace also silently accepted ASCII control bytes and DEL inside parameter names, which is now rejected to match the existing check on path bodies.