### PR TITLE
perf(lookup): short-circuit 1-byte keys and inline route.match

### DIFF
--- a/fox.go
+++ b/fox.go
@@ -361,6 +361,9 @@ func (fox *Router) Name(name string) *Route {
 // (trailing slash action recommended). This function is safe for concurrent use by multiple goroutine and while
 // mutation on routes are ongoing. See also [Router.Lookup] as an alternative.
 func (fox *Router) Match(method string, r *http.Request) (route *Route, tsr bool) {
+	if method == "" {
+		return nil, false
+	}
 	tree := fox.getTree()
 	c := tree.pool.Get().(*Context)
 	defer tree.pool.Put(c)
@@ -381,6 +384,9 @@ func (fox *Router) Match(method string, r *http.Request) (route *Route, tsr bool
 // [Route] and a [Context]. The [Context] should always be closed if non-nil. This function is safe for
 // concurrent use by multiple goroutine and while mutation on routes are ongoing. See also [Router.Match] as an alternative.
 func (fox *Router) Lookup(w ResponseWriter, r *http.Request) (route *Route, cc *Context, tsr bool) {
+	if r.Method == "" {
+		return nil, nil, false
+	}
 	tree := fox.getTree()
 	c := tree.pool.Get().(*Context)
 	c.resetWithWriter(w, r)
@@ -457,6 +463,10 @@ func (fox *Router) NewRoute(methods []string, pattern string, handler HandlerFun
 		copy(rte.methods, methods)
 		slices.Sort(rte.methods)
 		rte.methods = slices.Compact(rte.methods)
+	}
+
+	if len(rte.methods) == 1 && len(rte.matchers) == 0 {
+		rte.methodFast = rte.methods[0]
 	}
 
 	return rte, nil

--- a/node.go
+++ b/node.go
@@ -106,7 +106,10 @@ Walk:
 			if idx < num && matched.statics[idx].label == label {
 				child := matched.statics[idx]
 				keyLen := len(child.key)
-				if keyLen <= len(search) && stringsutil.EqualStringsASCIIIgnoreCase(search[:keyLen], child.key) {
+				// keyLen == 1 short-circuits the case-insensitive compare: hostname keys are
+				// stored lowercase (uppercase is rejected at parse time) and the label match
+				// already proved lowercase(search[0]) == child.key[0].
+				if keyLen == 1 || (keyLen <= len(search) && stringsutil.EqualStringsASCIIIgnoreCase(search[:keyLen], child.key)) {
 					if len(matched.params) > 0 || len(matched.wildcards) > 0 {
 						*c.skipStack = append(*c.skipStack, skipNode{
 							node:         matched,
@@ -332,8 +335,10 @@ Walk:
 				child := matched.statics[idx]
 				keyLen := len(child.key)
 				// While this is less performant than byte-by-byte comparaison for reasonable search size,
-				// direct == comparaison on string scale way better on long route.
-				if keyLen <= len(search) && search[:keyLen] == child.key {
+				// direct == comparaison on string scale way better on long route. The keyLen == 1 case
+				// short-circuits the memequal call: we already verified search[0] == child.key[0] via the
+				// label match above.
+				if keyLen == 1 || (keyLen <= len(search) && search[:keyLen] == child.key) {
 					if len(matched.params) > 0 || len(matched.wildcards) > 0 {
 						*c.skipStack = append(*c.skipStack, skipNode{
 							node:         matched,

--- a/route.go
+++ b/route.go
@@ -19,6 +19,7 @@ type Route struct {
 	mws         []middleware
 	params      []string
 	matchers    []Matcher
+	methodFast  string
 	pattern     pattern
 	priority    uint
 	handleSlash TrailingSlashOption
@@ -135,12 +136,27 @@ func (r *Route) String() string {
 // match reports whether the request satisfies this route's method constraint (if any)
 // and all attached matchers.
 func (r *Route) match(method string, c RequestContext) bool {
-	// Fast path for common cases: no methods or single method
+	// Fast path: routes with exactly one method and no matchers cache that
+	// method in methodFast.
+	if r.methodFast == method {
+		return true
+	}
+	return r.matchSlow(method, c)
+}
+
+// matchSlow handles the cases match's fast path does not cover: zero or many
+// methods, and routes with matchers. It is kept out-of-line so match remains
+// inlinable.
+//
+//go:noinline
+func (r *Route) matchSlow(method string, c RequestContext) bool {
 	methods := r.methods
 	switch len(methods) {
 	case 0:
-		// No method constraint
+		// No method constraint.
 	case 1:
+		// Avoid the slices.Contains overhead for the single-method case (which
+		// match's fast path leaves to us when matchers are present).
 		if methods[0] != method {
 			return false
 		}
@@ -149,7 +165,6 @@ func (r *Route) match(method string, c RequestContext) bool {
 			return false
 		}
 	}
-
 	for _, m := range r.matchers {
 		if !m.Match(c) {
 			return false

--- a/txn.go
+++ b/txn.go
@@ -285,6 +285,10 @@ func (txn *Txn) Match(method string, r *http.Request) (route *Route, tsr bool) {
 		panic(ErrSettledTxn)
 	}
 
+	if method == "" {
+		return nil, false
+	}
+
 	tree := txn.rootTxn.tree
 	c := tree.pool.Get().(*Context)
 	defer tree.pool.Put(c)
@@ -307,6 +311,10 @@ func (txn *Txn) Match(method string, r *http.Request) (route *Route, tsr bool) {
 func (txn *Txn) Lookup(w ResponseWriter, r *http.Request) (route *Route, cc *Context, tsr bool) {
 	if txn.rootTxn == nil {
 		panic(ErrSettledTxn)
+	}
+
+	if r.Method == "" {
+		return nil, nil, false
 	}
 
 	tree := txn.rootTxn.tree


### PR DESCRIPTION
This PR make two lookup-path optimizations giving 10 to 15 % performance improvement with no regression elsewhere.

After the static binary search lands on a child, the label match already proves search[0] == child.key[0]. So when the child key is exactly one byte, the runtime.memequal call (`search[:keyLen] == child.key`) is redundant and can be skipped. This sounds niche, but the radix tree forces "/" separators into their own nodes wherever they sit between two non-static neighbours, or between a param and a branching point. Both patterns are common in API. Two consecutive params, e.g. /repos/{owner}/{repo}, compress to:

```
root
└── "/repos/"
    └── "?" (param owner)
        └── "/"   ← isolated between two params
            └── "?" (param repo)
```

A param followed by a static branching point, e.g. /users/{id}/repos and /users/{id}/projects, compress to:

```
root
└── "/users/"
    └── "?" (param)
        └── "/"   ← isolated, cannot merge with either side
            ├── "projects"
            └── "repos"
``` 

In both cases the "/" cannot be merged into the param node above, and cannot merge into the static children below (either because the next node is a param, or because there are multiple static children). In the GitHub API fixture 47% of tree nodes have a 1-byte key, mostly those isolated "/" nodes, which is what makes the fast path worth it.

The second change inlines (*Route).match. We cache methods[0] in a new methodFast field for the common case (single method, no matchers), the rest moves to a `//go:noinline` matchSlow.


Differential Benchmark
```
goos: darwin
goarch: arm64
pkg: github.com/fox-toolkit/fox
cpu: Apple M4 Max
                        │ /tmp/baseline_all.txt │       /tmp/all_truly_final.txt       │
                        │        sec/op         │   sec/op     vs base                 │
StaticAll                          8.811µ ± ∞ ¹   7.861µ ± 1%  -10.78% (p=0.004 n=5+6)
GithubAll                          15.13µ ± ∞ ¹   13.18µ ± 1%  -12.84% (p=0.004 n=5+6)
StaticHostnameAll                  8.855µ ± ∞ ¹   8.372µ ± 1%   -5.45% (p=0.004 n=5+6)
GithubParamsAll                    70.02n ± ∞ ¹   59.50n ± 1%  -15.02% (p=0.004 n=5+6)
GithubParamsHostnameAll            61.43n ± ∞ ¹   58.12n ± 1%   -5.38% (p=0.004 n=5+6)
InfixCatchAll                      209.1n ± ∞ ¹   204.9n ± 0%   -2.01% (p=0.004 n=5+6)
LongParam                          26.72n ± ∞ ¹   25.52n ± 1%   -4.49% (p=0.004 n=5+6)
OverlappingRoute                   68.25n ± ∞ ¹   64.39n ± 1%   -5.66% (p=0.004 n=5+6)
WithIgnoreTrailingSlash            37.54n ± ∞ ¹   34.66n ± 1%   -7.69% (p=0.004 n=5+6)
CatchAll                           27.06n ± ∞ ¹   26.02n ± 1%   -3.82% (p=0.004 n=5+6)
VeryLongPattern                    82.53n ± ∞ ¹   81.18n ± 1%   -1.64% (p=0.004 n=5+6)
geomean                            241.4n         224.8n        -6.89%
```